### PR TITLE
add persistent secret p-tracking for query-level MIA composition

### DIFF
--- a/docs/pac/ptracking.md
+++ b/docs/pac/ptracking.md
@@ -1,0 +1,126 @@
+# Persistent Secret P-Tracking
+
+## Overview
+
+When `pac_ptracking` is enabled (default: `true`) and `pac_mi > 0`, the noise calibration step tracks a Bayesian posterior distribution `p` over the 64 worlds (bit positions) across all cells released by a query. This provides **query-level** membership inference attack (MIA) protection, rather than just cell-level.
+
+## Background
+
+PAC uses 64 subsamples (worlds) derived from the 64 bits of each privacy unit's key hash. For each query, one world `J` is selected as the "secret" — the same `J` for all output cells in that query.
+
+Without p-tracking, each cell independently calibrates noise using the uniform variance over the 64 counter values:
+
+```
+variance = sum((vals - mean)^2) / (N - 1)
+noise_var = variance / (2 * mi)
+```
+
+The problem: an adversary who observes all output cells can compose information across them. After seeing cell 1's noisy output, the adversary's belief about which world is the secret shifts from uniform to some posterior. Cell 2's noise should account for this shifted belief, but without p-tracking it doesn't.
+
+## How it works
+
+A probability vector `p` of dimension 64 is initialized to uniform `(1/64, ..., 1/64)` at the start of each query. For each cell that gets noised:
+
+### 1. Calibrate noise using p-weighted variance
+
+Instead of uniform variance, compute the variance weighted by the current posterior `p`:
+
+```
+mean = sum(vals[k] * p[k])
+variance = sum((vals[k] - mean)^2 * p[k])
+noise_var = variance / (2 * mi)
+```
+
+This corresponds to `get_noise_var(p, vals, b)` in the reference Python implementation.
+
+### 2. Add noise (unchanged)
+
+```
+noisy_result = vals[secret_J] + Normal(0, sqrt(noise_var))
+```
+
+### 3. Bayesian posterior update
+
+After observing the noisy result, update `p` using the likelihood of each world producing that result:
+
+```
+for each world k:
+    log_p[k] = log(p[k]) + log_likelihood[k]
+    where log_likelihood[k] = -0.5 * (vals[k] - noisy_result)^2 / noise_var
+
+p = softmax(log_p)   (via log-sum-exp for numerical stability)
+```
+
+This corresponds to `update_p(p, vals, noisy_result, noise_variance)` in the reference.
+
+As more cells are released, `p` concentrates around the true secret world. The p-weighted variance shrinks, causing the noise variance formula to produce **larger** noise to compensate — exactly what's needed for correct composition.
+
+## Implementation details
+
+### Cross-aggregate sharing
+
+The `p` vector is shared across all aggregate functions (pac_count, pac_sum, pac_avg, pac_min, pac_max, pac_aggregate) within the same query via a global map keyed by `query_hash`. This ensures that if a query computes both `pac_count` and `pac_sum`, the information leaked by count cells is accounted for when calibrating sum cells, and vice versa.
+
+### Concurrency
+
+A mutex protects the shared `p` state. Each noise operation locks, reads `p`, computes weighted variance, adds noise, updates `p`, and unlocks. This serialization is inherent to the approach — the collaborator noted "the noising step will have to be done sequentially."
+
+### Handling NULL counters
+
+When a group has fewer than 64 valid counters (some bit positions have no data), the `p` values for non-null worlds are extracted and renormalized to sum to 1 before computing weighted variance and doing the Bayesian update. The null worlds' `p` values are preserved unchanged.
+
+### Lifetime management
+
+The global map stores `weak_ptr` references. Each `PacBindData` instance holds a `shared_ptr` to the `PacPState`. When all `PacBindData` instances for a query are destroyed (query finishes), the `PacPState` is automatically freed and the expired `weak_ptr` is cleaned up lazily.
+
+## Configuration
+
+```sql
+-- Enable p-tracking (default)
+SET pac_ptracking = true;
+
+-- Disable p-tracking (fall back to cell-level MIA, same as PAC-DB)
+SET pac_ptracking = false;
+```
+
+P-tracking is only active when `pac_mi > 0`. When `pac_mi = 0` (deterministic mode), no noise is added and p-tracking has no effect.
+
+## Privacy guarantees
+
+| Setting | Guarantee |
+|---------|-----------|
+| `pac_ptracking = true` | Query-level MIA: adversary cannot infer if a record was used to answer **any cell** of the query |
+| `pac_ptracking = false` | Cell-level MIA: adversary cannot infer if a record was used for a **specific cell** (PAC-DB guarantee) |
+
+## Files modified
+
+- `src/include/aggregates/pac_aggregate.hpp` — `PacPState` struct, `shared_ptr<PacPState>` in `PacBindData`
+- `src/aggregates/pac_aggregate.cpp` — global map, p-weighted noise in `PacNoisySampleFrom64Counters` and `PacAggregateScalar`
+- `src/aggregates/pac_count.cpp` — passes `pstate` to noise function
+- `src/aggregates/pac_sum.cpp` — passes `pstate` to noise function (also covers pac_avg via template)
+- `src/aggregates/pac_min_max.cpp` — passes `pstate` to noise function
+- `src/categorical/pac_categorical.cpp` — `pstate` in `PacCategoricalBindData`, passes to noise function
+- `src/core/pac_extension.cpp` — registers `pac_ptracking` setting
+
+## Reference
+
+Based on the collaborator's Python reference implementation:
+
+```python
+def get_noise_var(p, vals, b):
+    mean = np.sum(vals * p)
+    centered = vals - mean
+    variance = np.sum(centered**2 * p)
+    noise_var = variance / (2 * b)
+    return noise_var
+
+def update_p(p, vals, noisy_result, noise_variance):
+    diff = vals - noisy_result
+    mahalanobis = (diff ** 2) / noise_variance
+    log_likelihoods = -0.5 * mahalanobis
+    log_p = np.log(p + 1e-300) + log_likelihoods
+    c = log_p.max()
+    log_sum = c + np.log(np.sum(np.exp(log_p - c)))
+    p = np.exp(log_p - log_sum)
+    return p
+```

--- a/src/aggregates/pac_aggregate.cpp
+++ b/src/aggregates/pac_aggregate.cpp
@@ -20,6 +20,34 @@
 
 namespace duckdb {
 
+// ============================================================================
+// Global PacPState map for cross-aggregate p-tracking within a query
+// ============================================================================
+static std::mutex g_pstate_map_mutex;
+static std::unordered_map<uint64_t, std::weak_ptr<PacPState>> g_pstate_map;
+
+std::shared_ptr<PacPState> GetOrCreatePState(uint64_t query_hash) {
+	std::lock_guard<std::mutex> lock(g_pstate_map_mutex);
+	auto it = g_pstate_map.find(query_hash);
+	if (it != g_pstate_map.end()) {
+		auto sp = it->second.lock();
+		if (sp) {
+			return sp;
+		}
+	}
+	auto sp = std::make_shared<PacPState>();
+	g_pstate_map[query_hash] = sp;
+	// Lazily clean up expired entries (cheap: just scan for expired weak_ptrs)
+	for (auto iter = g_pstate_map.begin(); iter != g_pstate_map.end();) {
+		if (iter->second.expired()) {
+			iter = g_pstate_map.erase(iter);
+		} else {
+			++iter;
+		}
+	}
+	return sp;
+}
+
 // Helper function to generate a random seed - implementation
 uint64_t PacGenerateRandomSeed() {
 	return std::random_device {}();
@@ -139,17 +167,23 @@ bool PacNoiseInNull(uint64_t key_hash, double mi, double correction, std::mt1993
 // is_null: bitmask where bit i=1 means counter i should be excluded (compacted out)
 // mi: mutual information parameter for noise calculation
 // correction: factor to multiply values by after compacting but before noising
+// pstate: optional p-tracking state for persistent secret composition (Bayesian posterior over worlds)
 // Returns: correction*yJ + noise where yJ is a randomly selected counter
 PAC_FLOAT PacNoisySampleFrom64Counters(const PAC_FLOAT counters[64], double mi, double correction, std::mt19937_64 &gen,
-                                       bool use_deterministic_noise, uint64_t is_null, uint64_t counter_selector) {
+                                       bool use_deterministic_noise, uint64_t is_null, uint64_t counter_selector,
+                                       std::shared_ptr<PacPState> pstate) {
 	D_ASSERT(~is_null != 0); // at least one bit must be valid
 
 	// Compact the counters array, removing entries where is_null bit is set
+	// Also track mapping from compacted index back to original world index (needed for p-tracking)
 	vector<PAC_FLOAT> vals;
+	vector<int> world_map; // world_map[k] = original bit position for compacted index k
 	vals.reserve(64);
+	world_map.reserve(64);
 	for (int i = 0; i < 64; i++) {
 		if (!((is_null >> i) & 1)) {
 			vals.push_back(counters[i]);
+			world_map.push_back(i);
 		}
 	}
 
@@ -164,13 +198,97 @@ PAC_FLOAT PacNoisySampleFrom64Counters(const PAC_FLOAT counters[64], double mi, 
 	}
 	int N = static_cast<int>(vals.size());
 
-	// Compute delta using the shared exported helper (uses mi for noise variance)
-	double delta = ComputeDeltaFromValues(vals, mi);
-
 	// Pick counter index J in [0, N-1] deterministically from counter_selector.
 	// This ensures all aggregates within the same query pick the same counter (after compacting).
 	int J = static_cast<int>(counter_selector % static_cast<uint64_t>(N));
 	PAC_FLOAT yJ = vals[J];
+
+	// ---- P-tracking path: use p-weighted variance and Bayesian update ----
+	// Corresponds to collaborator's get_noise_var(p, vals, b) and update_p(p, vals, noisy_result, noise_var)
+	if (pstate) {
+		std::lock_guard<std::mutex> lock(pstate->mtx);
+
+		// Extract and renormalize p for the non-null worlds in this group
+		double p_local[64]; // compacted p values (only N entries used)
+		double p_sum = 0.0;
+		for (int k = 0; k < N; k++) {
+			p_local[k] = pstate->p[world_map[k]];
+			p_sum += p_local[k];
+		}
+		if (p_sum <= 0.0) {
+			// All worlds have zero probability — shouldn't happen, fall through to uniform
+			goto uniform_path;
+		}
+		for (int k = 0; k < N; k++) {
+			p_local[k] /= p_sum; // renormalize to sum to 1 over non-null worlds
+		}
+
+		{
+			// get_noise_var(p, vals, b): p-weighted mean and variance
+			double w_mean = 0.0;
+			for (int k = 0; k < N; k++) {
+				w_mean += static_cast<double>(vals[k]) * p_local[k];
+			}
+			double w_var = 0.0;
+			for (int k = 0; k < N; k++) {
+				double d = static_cast<double>(vals[k]) - w_mean;
+				w_var += d * d * p_local[k];
+			}
+			double noise_var = w_var / (2.0 * mi);
+
+			if (noise_var <= 0.0 || !std::isfinite(noise_var)) {
+				return yJ; // no variance — no noise needed
+			}
+
+			// Sample noise
+			double noise;
+			if (use_deterministic_noise) {
+				double u1 = DeterministicUniformUnit(gen);
+				double u2 = DeterministicUniformUnit(gen);
+				if (u1 <= 0.0) {
+					u1 = std::numeric_limits<double>::min();
+				}
+				double r = std::sqrt(-2.0 * std::log(u1));
+				double theta = 2.0 * M_PI * u2;
+				double z0 = r * std::cos(theta);
+				noise = z0 * std::sqrt(noise_var);
+			} else {
+				std::normal_distribution<double> normal_dist(0.0, std::sqrt(noise_var));
+				noise = normal_dist(gen);
+			}
+			double noisy_result = static_cast<double>(yJ) + noise;
+
+			// update_p(p, vals, noisy_result, noise_var): Bayesian posterior update
+			// log_p[k] = log(p[k]) + log_likelihood[k], then log-sum-exp normalize
+			double log_p[64];
+			double max_log = -std::numeric_limits<double>::infinity();
+			for (int k = 0; k < N; k++) {
+				double diff = static_cast<double>(vals[k]) - noisy_result;
+				log_p[k] = std::log(p_local[k] + 1e-300) + (-0.5 * diff * diff / noise_var);
+				if (log_p[k] > max_log) {
+					max_log = log_p[k];
+				}
+			}
+			// Log-sum-exp normalization
+			double sum_exp = 0.0;
+			for (int k = 0; k < N; k++) {
+				sum_exp += std::exp(log_p[k] - max_log);
+			}
+			double log_sum = max_log + std::log(sum_exp);
+			// Write updated p back to pstate, scaled by p_sum to preserve probability mass
+			// of null worlds (their p values don't change from this cell's observation)
+			for (int k = 0; k < N; k++) {
+				pstate->p[world_map[k]] = std::exp(log_p[k] - log_sum) * p_sum;
+			}
+
+			return static_cast<PAC_FLOAT>(noisy_result);
+		}
+	}
+
+uniform_path:
+	// ---- Original uniform path (no p-tracking) ----
+	// Compute delta using the shared exported helper (uses mi for noise variance)
+	double delta = ComputeDeltaFromValues(vals, mi);
 
 	if (delta <= 0.0 || !std::isfinite(delta)) {
 		// If there's no variance, return the selected counter value without noise.
@@ -270,11 +388,14 @@ static void PacAggregateScalar(DataChunk &args, ExpressionState &state, Vector &
 	auto &local = ExecuteFunctionState::GetFunctionState(state)->Cast<PacAggregateLocalState>();
 	auto &gen = local.gen;
 
-	// Get query_hash from bind data for deterministic counter selection
+	// Get query_hash and pstate from bind data for deterministic counter selection and p-tracking
 	uint64_t query_hash = 0;
+	std::shared_ptr<PacPState> pstate;
 	auto &bound_expr = state.expr.Cast<BoundFunctionExpression>();
 	if (bound_expr.bind_info) {
-		query_hash = bound_expr.bind_info->Cast<PacBindData>().query_hash;
+		auto &bd = bound_expr.bind_info->Cast<PacBindData>();
+		query_hash = bd.query_hash;
+		pstate = bd.pstate;
 	}
 
 	// --- extract lists ---
@@ -356,9 +477,64 @@ static void PacAggregateScalar(DataChunk &args, ExpressionState &state, Vector &
 			continue;
 		}
 
+		idx_t N = values.size();
 		// 1. pick J deterministically from query_hash (same within a query)
-		idx_t J = static_cast<idx_t>(query_hash % static_cast<uint64_t>(values.size()));
+		idx_t J = static_cast<idx_t>(query_hash % static_cast<uint64_t>(N));
 		PAC_FLOAT yJ = values[J];
+
+		// P-tracking path for pac_aggregate scalar (only when list fits in 64 worlds)
+		if (pstate && N <= 64) {
+			std::lock_guard<std::mutex> lock(pstate->mtx);
+			// For pac_aggregate, values are already in compacted form (list input, no is_null mask).
+			// Use indices 0..N-1 directly as world indices for p-tracking.
+			double p_local[64];
+			double p_sum = 0.0;
+			for (idx_t k = 0; k < N; k++) {
+				p_local[k] = pstate->p[k];
+				p_sum += p_local[k];
+			}
+			if (p_sum > 0.0) {
+				for (idx_t k = 0; k < N; k++) {
+					p_local[k] /= p_sum;
+				}
+				double w_mean = 0.0;
+				for (idx_t k = 0; k < N; k++) {
+					w_mean += static_cast<double>(values[k]) * p_local[k];
+				}
+				double w_var = 0.0;
+				for (idx_t k = 0; k < N; k++) {
+					double d = static_cast<double>(values[k]) - w_mean;
+					w_var += d * d * p_local[k];
+				}
+				double noise_var = w_var / (2.0 * mi);
+				if (noise_var > 0.0 && std::isfinite(noise_var)) {
+					double noise = DeterministicNormalSample(gen, local.has_spare, local.spare, 0.0,
+					                                        std::sqrt(noise_var));
+					double noisy_result = static_cast<double>(yJ) + noise;
+					// Bayesian update
+					double log_p[64];
+					double max_log = -std::numeric_limits<double>::infinity();
+					for (idx_t k = 0; k < N; k++) {
+						double diff = static_cast<double>(values[k]) - noisy_result;
+						log_p[k] = std::log(p_local[k] + 1e-300) + (-0.5 * diff * diff / noise_var);
+						if (log_p[k] > max_log) {
+							max_log = log_p[k];
+						}
+					}
+					double sum_exp = 0.0;
+					for (idx_t k = 0; k < N; k++) {
+						sum_exp += std::exp(log_p[k] - max_log);
+					}
+					double log_sum = max_log + std::log(sum_exp);
+					for (idx_t k = 0; k < N; k++) {
+						pstate->p[k] = std::exp(log_p[k] - log_sum) * p_sum;
+					}
+					res[row] = noisy_result;
+					continue;
+				}
+			}
+			// Fall through to uniform path if p_sum == 0 or no variance
+		}
 
 		// 2. empirical (second-moment) variance over the full list
 		double delta = ComputeDeltaFromValues(values, mi);

--- a/src/aggregates/pac_min_max.cpp
+++ b/src/aggregates/pac_min_max.cpp
@@ -95,6 +95,7 @@ static void PacMinMaxFinalize(Vector &states, AggregateInputData &input, Vector 
 	double mi = input.bind_data ? input.bind_data->Cast<PacBindData>().mi : 0.0;
 	double correction = input.bind_data ? input.bind_data->Cast<PacBindData>().correction : 1.0;
 	uint64_t query_hash = input.bind_data ? input.bind_data->Cast<PacBindData>().query_hash : 0;
+	auto pstate = input.bind_data ? input.bind_data->Cast<PacBindData>().pstate : nullptr;
 
 	for (idx_t i = 0; i < count; i++) {
 #ifndef PAC_NOBUFFERING
@@ -119,7 +120,8 @@ static void PacMinMaxFinalize(Vector &states, AggregateInputData &input, Vector 
 		CheckPacSampleDiversity(key_hash, buf, s ? s->update_count : 0, IS_MAX ? "pac_max" : "pac_min",
 		                        input.bind_data->Cast<PacBindData>());
 		// Pass mi for noise, 1.0 as correction (no value scaling for min/max)
-		data[offset + i] = FromDouble<T>(PacNoisySampleFrom64Counters(buf, mi, 1.0, gen, true, ~key_hash, query_hash));
+		data[offset + i] =
+		    FromDouble<T>(PacNoisySampleFrom64Counters(buf, mi, 1.0, gen, true, ~key_hash, query_hash, pstate));
 	}
 }
 

--- a/src/aggregates/pac_sum.cpp
+++ b/src/aggregates/pac_sum.cpp
@@ -405,6 +405,7 @@ void PacSumFinalize(Vector &states, AggregateInputData &input, Vector &result, i
 	uint64_t query_hash = input.bind_data ? input.bind_data->Cast<PacBindData>().query_hash : 0;
 	// scale_divisor is used by pac_avg on DECIMAL to convert internal integer representation back to decimal
 	double scale_divisor = input.bind_data ? input.bind_data->Cast<PacBindData>().scale_divisor : 1.0;
+	auto pstate = input.bind_data ? input.bind_data->Cast<PacBindData>().pstate : nullptr;
 
 	for (idx_t i = 0; i < count; i++) {
 #ifndef PAC_NOBUFFERING
@@ -442,7 +443,8 @@ void PacSumFinalize(Vector &states, AggregateInputData &input, Vector &result, i
 		}
 		CheckPacSampleDiversity(key_hash, buf, update_count, DIVIDE_BY_COUNT ? "pac_avg" : "pac_sum",
 		                        input.bind_data->Cast<PacBindData>());
-		PAC_FLOAT result_val = PacNoisySampleFrom64Counters(buf, mi, correction, gen, true, ~key_hash, query_hash);
+		PAC_FLOAT result_val =
+		    PacNoisySampleFrom64Counters(buf, mi, correction, gen, true, ~key_hash, query_hash, pstate);
 		// Both pac_sum and pac_avg need 2x compensation:
 		// - pac_sum: doubles the sum to compensate for ~50% of values contributing to each counter
 		// - pac_avg: compensates for dividing by total_count instead of per-counter count

--- a/src/core/pac_extension.cpp
+++ b/src/core/pac_extension.cpp
@@ -212,6 +212,12 @@ static void LoadInternal(ExtensionLoader &loader) {
 	// Add option to control whether pac_hash() repairs hashes to exactly 32 bits set
 	db.config.AddExtensionOption("pac_hash_repair", "pac_hash() repairs hash to exactly 32 bits set",
 	                             LogicalType::BOOLEAN, Value::BOOLEAN(true));
+	// Add option to enable/disable persistent secret p-tracking for correct query-level privacy composition.
+	// When enabled (default), noise calibration tracks a Bayesian posterior over worlds across all cells
+	// in a query, providing query-level MIA protection. When disabled, each cell uses uniform variance
+	// independently (cell-level MIA only). Only active when pac_mi > 0.
+	db.config.AddExtensionOption("pac_ptracking", "enable persistent secret p-tracking for query-level MIA",
+	                             LogicalType::BOOLEAN, Value::BOOLEAN(true));
 
 	// Register pac_aggregate function(s)
 	RegisterPacAggregateFunctions(loader);


### PR DESCRIPTION
Track a Bayesian posterior distribution p over the 64 worlds across all cells in a query. Noise calibration uses p-weighted variance (get_noise_var) and updates p after each noisy release (update_p), providing query-level membership inference attack protection instead of just cell-level.

- New PacPState struct with mutex + p[64], shared across aggregates via global weak_ptr map keyed by query_hash
- Modified PacNoisySampleFrom64Counters to support p-weighted path
- New pac_ptracking setting (default true, only active when pac_mi > 0)
- All finalize call sites pass pstate (pac_count, pac_sum, pac_min_max, pac_categorical, pac_aggregate)