### PR TITLE
Use global mean unnoised for top-k

### DIFF
--- a/src/query_processing/pac_topk_rewriter.cpp
+++ b/src/query_processing/pac_topk_rewriter.cpp
@@ -192,23 +192,24 @@ void RegisterPacUnnoisedFunction(ExtensionLoader &loader) {
 // re-ranked by the final TopN.
 //
 // This is implemented as a custom DuckDB window aggregate:
-//   window_init: scans all rows, ranks by counter[J] descending, marks
-//                top-K rows in a boolean vector
+//   window_init: for each of the 64 worlds, independently find the top-K groups
+//                by that world's counter value, then union all 64 per-world top-K
+//                sets to form the superset (marks membership in a boolean vector)
 //   window:      returns the precomputed boolean for each row
 // ============================================================================
 
-// Bind data: stores K (the TopN limit) and the world index J
+// Bind data: stores K (the per-world TopN limit) and the ranking direction
 struct PacTopKSupersetBindData : public FunctionData {
 	idx_t k;
-	idx_t world_idx; // J = query_hash % 64
-	PacTopKSupersetBindData(idx_t k, idx_t world_idx) : k(k), world_idx(world_idx) {
+	bool ascending; // true if ORDER BY ASC (per-world ranking picks smallest K), false for DESC (largest K)
+	PacTopKSupersetBindData(idx_t k, bool ascending) : k(k), ascending(ascending) {
 	}
 	unique_ptr<FunctionData> Copy() const override {
-		return make_uniq<PacTopKSupersetBindData>(k, world_idx);
+		return make_uniq<PacTopKSupersetBindData>(k, ascending);
 	}
 	bool Equals(const FunctionData &other) const override {
 		auto &o = other.Cast<PacTopKSupersetBindData>();
-		return k == o.k && world_idx == o.world_idx;
+		return k == o.k && ascending == o.ascending;
 	}
 };
 
@@ -235,13 +236,16 @@ static void PacTopKSupersetDestroy(Vector &state_vec, AggregateInputData &, idx_
 	}
 }
 
-// window_init: scan all rows, rank by counter[J] descending, mark top-K
+// window_init: for each of the 64 worlds, independently find the top-K groups
+// by that world's counter value, then take the union of all 64 per-world top-K
+// sets as the superset. This ensures the superset is determined by ALL worlds
+// (not just the secret world), preserving PAC privacy for the output key set.
 static void PacTopKSupersetWindowInit(AggregateInputData &aggr_input_data, const WindowPartitionInput &partition,
                                       data_ptr_t g_state) {
 	auto &state = *reinterpret_cast<PacTopKSupersetState *>(g_state);
 	auto &bind_data = aggr_input_data.bind_data->Cast<PacTopKSupersetBindData>();
 	idx_t K = bind_data.k;
-	idx_t J = bind_data.world_idx;
+	bool ascending = bind_data.ascending;
 	auto count = partition.count;
 
 	state.in_superset.resize(count, false);
@@ -249,9 +253,15 @@ static void PacTopKSupersetWindowInit(AggregateInputData &aggr_input_data, const
 		return;
 	}
 
-	// Collect counter[J] for every row: (row_idx, value)
-	vector<pair<idx_t, PAC_FLOAT>> values;
-	values.reserve(count);
+	// If K >= count, all groups are in the superset (no filtering needed)
+	if (K >= count) {
+		std::fill(state.in_superset.begin(), state.in_superset.end(), true);
+		return;
+	}
+
+	// Step 1: Collect all 64 counter values for every row.
+	// Flat layout: all_counters[row * 64 + world] = counter value
+	vector<PAC_FLOAT> all_counters(count * 64, PAC_FLOAT(0));
 
 	auto *inputs = partition.inputs;
 	auto counters_col_idx = partition.column_ids[0]; // first argument = counters list
@@ -278,37 +288,57 @@ static void PacTopKSupersetWindowInit(AggregateInputData &aggr_input_data, const
 		for (idx_t i = 0; i < chunk_size; i++) {
 			auto list_idx = list_data.sel->get_index(i);
 
-			if (!list_data.validity.RowIsValid(list_idx)) {
-				// NULL list → treat as 0 for this world
-				values.emplace_back(row_offset, PAC_FLOAT(0));
-				row_offset++;
-				continue;
-			}
-
-			auto &entry = list_entries[list_idx];
-			PAC_FLOAT val = 0;
-			if (J < entry.length) {
-				auto child_idx = child_data.sel->get_index(entry.offset + J);
-				if (child_data.validity.RowIsValid(child_idx)) {
-					val = child_values[child_idx];
+			if (list_data.validity.RowIsValid(list_idx)) {
+				auto &entry = list_entries[list_idx];
+				idx_t num_counters = std::min(entry.length, idx_t(64));
+				for (idx_t j = 0; j < num_counters; j++) {
+					auto child_idx = child_data.sel->get_index(entry.offset + j);
+					if (child_data.validity.RowIsValid(child_idx)) {
+						all_counters[row_offset * 64 + j] = child_values[child_idx];
+					}
 				}
 			}
-			values.emplace_back(row_offset, val);
 			row_offset++;
 		}
 	}
 
-	// Sort descending by counter[J] and mark top-K rows
-	std::sort(values.begin(), values.end(),
-	          [](const pair<idx_t, PAC_FLOAT> &a, const pair<idx_t, PAC_FLOAT> &b) { return a.second > b.second; });
-	idx_t top_k = std::min(K, static_cast<idx_t>(values.size()));
-	for (idx_t i = 0; i < top_k; i++) {
-		state.in_superset[values[i].first] = true;
+	// Step 2: For each world w (0..63), find the top-K groups by counter[w]
+	// and add them to the union superset.
+	vector<pair<idx_t, PAC_FLOAT>> world_values(count);
+
+	for (idx_t w = 0; w < 64; w++) {
+		// Extract (row_idx, counter[w]) for all rows
+		for (idx_t r = 0; r < count; r++) {
+			world_values[r] = {r, all_counters[r * 64 + w]};
+		}
+
+		// Partial sort: nth_element places the K-th element at position K-1,
+		// with all elements before it being the top-K (in unspecified order).
+		if (ascending) {
+			std::nth_element(world_values.begin(), world_values.begin() + static_cast<ptrdiff_t>(K),
+			                 world_values.end(),
+			                 [](const pair<idx_t, PAC_FLOAT> &a, const pair<idx_t, PAC_FLOAT> &b) { return a.second < b.second; });
+		} else {
+			std::nth_element(world_values.begin(), world_values.begin() + static_cast<ptrdiff_t>(K),
+			                 world_values.end(),
+			                 [](const pair<idx_t, PAC_FLOAT> &a, const pair<idx_t, PAC_FLOAT> &b) { return a.second > b.second; });
+		}
+
+		// Mark the top-K rows for this world in the union
+		for (idx_t i = 0; i < K; i++) {
+			state.in_superset[world_values[i].first] = true;
+		}
 	}
 
 #if PAC_DEBUG
-	PAC_DEBUG_PRINT("pac_topk_superset: K=" + std::to_string(K) + " world_idx=" + std::to_string(J) +
-	                " total_groups=" + std::to_string(count) + " selected=" + std::to_string(top_k));
+	idx_t superset_size = 0;
+	for (idx_t i = 0; i < count; i++) {
+		if (state.in_superset[i]) superset_size++;
+	}
+	PAC_DEBUG_PRINT("pac_topk_superset: K=" + std::to_string(K) +
+	                " ascending=" + std::to_string(ascending) +
+	                " total_groups=" + std::to_string(count) +
+	                " superset_size=" + std::to_string(superset_size));
 #endif
 }
 
@@ -758,29 +788,33 @@ void PACTopKRule::PACTopKOptimizeFunction(OptimizerExtensionInput &input, unique
 	}
 
 	// ==========================================================================
-	// Step 2: Per-world local top-K ranking via window function.
+	// Step 2: Union-of-all-worlds top-K ranking via window function.
 	//
-	// Per Xiaochen's approach: for each world w (0..63), independently rank
-	// all groups by counter[w] and select the top-K. The union of all 64
-	// per-world top-K sets forms the superset. Only superset members are
-	// noised and considered for the final top-K selection.
+	// For each world w (0..63), independently rank all groups by counter[w]
+	// and select the top-K. The union of all 64 per-world top-K sets forms
+	// the superset. This is privacy-safe because the superset is determined
+	// by ALL worlds (public), not any single secret world. Only superset
+	// members are noised and considered for the final top-K selection.
 	//
 	// Plan structure (both PATH A and PATH B):
-	//   FinalTopN(K, ORDER BY noised DESC)
-	//     → NoisedProj(pac_noised(counters, keyhash), passthrough group_cols)
-	//       → Filter(superset_flag = TRUE)
-	//         → Window(pac_topk_superset(counters) OVER () as superset_flag)
-	//           → [IntermediateProjs?] → Aggregate(_counters + keyhash)
+	//   NoisedProj(pac_noised(counters, keyhash) for output values only)
+	//     → FinalTopN(K, ORDER BY pac_mean DESC)
+	//       → RankProj(pac_mean(counters) for ranking, passthrough counters+keyhash)
+	//         → Filter(superset_flag = TRUE)
+	//           → Window(pac_topk_superset(counters) OVER () as superset_flag)
+	//             → [IntermediateProjs?] → Aggregate(_counters + keyhash)
 	// ==========================================================================
 #if PAC_DEBUG
 	PAC_DEBUG_PRINT("PACTopKRule: Step 2 - Building per-world ranking pipeline");
 #endif
 
-	// Determine which PAC aggregate the ORDER BY references (for ranking).
-	// Default to the first PAC aggregate.
+	// Determine which PAC aggregate the ORDER BY references (for ranking)
+	// and capture the sort direction for per-world ranking.
 	idx_t ranking_agg_idx = 0;
+	bool ranking_ascending = false; // default to descending (most top-k queries use DESC)
 	for (idx_t oi = 0; oi < ctx.topn->orders.size(); oi++) {
 		if (OrderExprReferencesPacAgg(*ctx.topn->orders[oi].expression, pac_aggs, ctx.intermediate_projections, 0)) {
+			ranking_ascending = (ctx.topn->orders[oi].type == OrderType::ASCENDING);
 			// Find which PAC agg this order references
 			for (idx_t j = 0; j < pac_aggs.size(); j++) {
 				auto *stripped = StripCasts(ctx.topn->orders[oi].expression.get());
@@ -1015,26 +1049,8 @@ void PACTopKRule::PACTopKOptimizeFunction(OptimizerExtensionInput &input, unique
 	                                              PacTopKSupersetWindow);
 	aggr_func->window_init = PacTopKSupersetWindowInit;
 
-	// Compute world index J = query_hash % 64, using the same formula as PacBindData
-	// so that the world used for top-K ranking is consistent with the world used
-	// by PacNoisySampleFrom64Counters for noise generation.
-	idx_t world_idx = 0;
-	{
-		uint64_t seed = 42;
-		Value pac_seed_val;
-		if (input.context.TryGetCurrentSetting("pac_seed", pac_seed_val) && !pac_seed_val.IsNull()) {
-			seed = static_cast<uint64_t>(pac_seed_val.GetValue<int64_t>());
-		}
-		double mi = GetPacMiFromSetting(input.context);
-		if (mi != 0.0) {
-			seed ^= PAC_MAGIC_HASH * static_cast<uint64_t>(input.context.ActiveTransaction().GetActiveQuery());
-		}
-		uint64_t query_hash = (seed * PAC_MAGIC_HASH) ^ PAC_MAGIC_HASH;
-		world_idx = query_hash % 64;
-	}
-
 	// Read expansion factor c (default 1.0). The window function selects
-	// ceil(c * K) candidates from world J; the final TopN limits to K.
+	// ceil(c * K) candidates per world for the union; the final TopN limits to K.
 	double expansion = 1.0;
 	Value exp_val;
 	if (input.context.TryGetCurrentSetting("pac_topk_expansion", exp_val) && !exp_val.IsNull()) {
@@ -1045,7 +1061,7 @@ void PACTopKRule::PACTopKOptimizeFunction(OptimizerExtensionInput &input, unique
 	}
 	idx_t expanded_k = static_cast<idx_t>(std::ceil(expansion * static_cast<double>(ctx.topn->limit)));
 
-	auto bind_data = make_uniq<PacTopKSupersetBindData>(expanded_k, world_idx);
+	auto bind_data = make_uniq<PacTopKSupersetBindData>(expanded_k, ranking_ascending);
 	auto window_expr = make_uniq<BoundWindowExpression>(ExpressionType::WINDOW_AGGREGATE, LogicalType::BOOLEAN,
 	                                                    std::move(aggr_func), std::move(bind_data));
 	// Counters list is the sole argument
@@ -1083,22 +1099,43 @@ void PACTopKRule::PACTopKOptimizeFunction(OptimizerExtensionInput &input, unique
 	filter_op->children.push_back(std::move(window_op));
 	filter_op->ResolveOperatorTypes();
 
-	// ---- Step 2c: Create NoisedProj above Filter ----
-	// The filter output = window child columns + superset_flag (all passed through).
-	// NoisedProj: for PAC aggregate columns -> pac_noised(counters, keyhash), cast to original type
-	//             for non-PAC columns -> passthrough
-	//             skip keyhash and superset_flag columns
+	// ---- Step 2c: Create RankProj above Filter ----
+	// RankProj uses pac_mean (mean of all 64 counters) for deterministic, low-variance
+	// ranking. This is privacy-safe because pac_mean is independent of the secret world.
+	// RankProj also passes through raw counters and keyhash so that NoisedProj (after
+	// FinalTopN) can apply pac_noised to the final K rows only.
+	//
+	// RankProj outputs (in column order matching original binding order):
+	//   - non-PAC columns: passthrough
+	//   - PAC aggregate columns: pac_mean(counters) for ranking, THEN raw counters passthrough
+	//   - keyhash: passthrough (for later noising)
+	//
+	// After FinalTopN selects K rows by pac_mean ranking, NoisedProj replaces
+	// pac_mean with pac_noised(counters, keyhash) and strips intermediate columns.
 	auto filter_bindings = filter_op->GetColumnBindings();
 	auto &filter_types = filter_op->types;
 
-	idx_t noised_proj_idx = binder.GenerateTableIndex();
-	vector<unique_ptr<Expression>> noised_proj_exprs;
+	idx_t rank_proj_idx = binder.GenerateTableIndex();
+	vector<unique_ptr<Expression>> rank_proj_exprs;
 
-	// Map: original column binding -> NoisedProj column index (for ORDER BY remap)
+	// Map: original column binding -> RankProj column index (for ORDER BY remap to pac_mean)
 	unordered_map<uint64_t, ColumnBinding> order_remap;
 
-	// Determine which filter output columns are PAC aggregates
-	// (trace through window -> [projections?] -> aggregate)
+	// Per-column output spec for NoisedProj to reconstruct the correct column order
+	enum class RankColKind { PASSTHROUGH, PAC_MEAN, PAC_COUNTERS, KEYHASH };
+	struct RankColSpec {
+		RankColKind kind;
+		idx_t rank_col;      // column index in RankProj
+		idx_t pac_idx;       // for PAC_MEAN/PAC_COUNTERS: index into pac_aggs
+		LogicalType type;    // for PASSTHROUGH: original type
+	};
+	vector<RankColSpec> rank_specs;
+
+	// Track PAC counters passthrough indices (for NoisedProj to reference)
+	// pac_agg_idx -> RankProj column index of raw counters passthrough
+	unordered_map<idx_t, idx_t> pac_counters_rank_col;
+	idx_t keyhash_rank_col = idx_t(-1);
+
 	auto child_bindings_before_window = ctx.has_intermediate_projection
 	                                        ? ctx.intermediate_projections[0]->GetColumnBindings()
 	                                        : agg.GetColumnBindings();
@@ -1108,11 +1145,11 @@ void PACTopKRule::PACTopKOptimizeFunction(OptimizerExtensionInput &input, unique
 		if (filter_bindings[i] == superset_flag_binding) {
 			continue;
 		}
-		// Skip keyhash column
+
+		// Check if this is keyhash
+		bool is_keyhash = false;
 		if (i < child_bindings_before_window.size()) {
-			bool is_keyhash = false;
 			if (ctx.has_intermediate_projection) {
-				// In PATH A, check if this outermost proj column traces to keyhash
 				auto *outermost = ctx.intermediate_projections[0];
 				if (filter_bindings[i].table_index == outermost->table_index) {
 					auto col_idx = filter_bindings[i].column_index;
@@ -1129,9 +1166,15 @@ void PACTopKRule::PACTopKOptimizeFunction(OptimizerExtensionInput &input, unique
 			} else {
 				is_keyhash = (i == keyhash_agg_bindings_idx);
 			}
-			if (is_keyhash) {
-				continue;
-			}
+		}
+
+		if (is_keyhash) {
+			// Passthrough keyhash for later noising
+			keyhash_rank_col = rank_proj_exprs.size();
+			auto ref = make_uniq<BoundColumnRefExpression>(filter_types[i], filter_bindings[i]);
+			rank_proj_exprs.push_back(std::move(ref));
+			rank_specs.push_back({RankColKind::KEYHASH, keyhash_rank_col, 0, filter_types[i]});
+			continue;
 		}
 
 		// Check if this is a PAC aggregate column
@@ -1167,81 +1210,137 @@ void PACTopKRule::PACTopKOptimizeFunction(OptimizerExtensionInput &input, unique
 			}
 		}
 
-		idx_t noised_col_idx = noised_proj_exprs.size();
-
 		if (is_pac) {
-			// PAC aggregate column: apply pac_noised, cast to original type
-			auto counters_ref = make_uniq<BoundColumnRefExpression>(list_type, filter_bindings[i]);
-			unique_ptr<Expression> keyhash_ref;
-			if (window_has_keyhash) {
-				keyhash_ref = make_uniq<BoundColumnRefExpression>(LogicalType::UBIGINT, window_keyhash_binding);
+			// PAC aggregate: emit pac_mean(counters) for ranking
+			idx_t mean_col = rank_proj_exprs.size();
+			auto counters_ref_mean = make_uniq<BoundColumnRefExpression>(list_type, filter_bindings[i]);
+			auto mean_expr = input.optimizer.BindScalarFunction("pac_mean", std::move(counters_ref_mean));
+			rank_proj_exprs.push_back(std::move(mean_expr));
+			rank_specs.push_back({RankColKind::PAC_MEAN, mean_col, pac_idx, PacFloatLogicalType()});
+
+			// Also emit raw counters passthrough for later noising
+			idx_t counters_col = rank_proj_exprs.size();
+			auto counters_passthrough = make_uniq<BoundColumnRefExpression>(list_type, filter_bindings[i]);
+			rank_proj_exprs.push_back(std::move(counters_passthrough));
+			rank_specs.push_back({RankColKind::PAC_COUNTERS, counters_col, pac_idx, list_type});
+			pac_counters_rank_col[pac_idx] = counters_col;
+
+			// ORDER BY remap points to pac_mean column (not noised, not counters)
+			if (ctx.has_intermediate_projection) {
+				auto *outermost = ctx.intermediate_projections[0];
+				if (filter_bindings[i].table_index == outermost->table_index) {
+					order_remap[HashBinding(filter_bindings[i])] = ColumnBinding(rank_proj_idx, mean_col);
+				}
 			} else {
-				keyhash_ref = make_uniq<BoundConstantExpression>(Value::UBIGINT(~uint64_t(0)));
+				order_remap[HashBinding(filter_bindings[i])] = ColumnBinding(rank_proj_idx, mean_col);
 			}
-			auto noised =
-			    input.optimizer.BindScalarFunction("pac_noised", std::move(counters_ref), std::move(keyhash_ref));
-			auto &orig_type = pac_aggs[pac_idx].original_type;
-			if (orig_type != noised->return_type) {
-				noised = BoundCastExpression::AddCastToType(input.context, std::move(noised), orig_type);
-			}
-			noised_proj_exprs.push_back(std::move(noised));
 		} else {
 			// Non-PAC column: passthrough
+			idx_t col = rank_proj_exprs.size();
 			auto ref = make_uniq<BoundColumnRefExpression>(filter_types[i], filter_bindings[i]);
-			noised_proj_exprs.push_back(std::move(ref));
-		}
+			rank_proj_exprs.push_back(std::move(ref));
+			rank_specs.push_back({RankColKind::PASSTHROUGH, col, 0, filter_types[i]});
 
-		// Build order remap: original binding -> NoisedProj column
-		if (ctx.has_intermediate_projection) {
-			auto *outermost = ctx.intermediate_projections[0];
-			if (filter_bindings[i].table_index == outermost->table_index) {
-				order_remap[HashBinding(filter_bindings[i])] = ColumnBinding(noised_proj_idx, noised_col_idx);
+			// ORDER BY remap for non-PAC columns
+			if (ctx.has_intermediate_projection) {
+				auto *outermost = ctx.intermediate_projections[0];
+				if (filter_bindings[i].table_index == outermost->table_index) {
+					order_remap[HashBinding(filter_bindings[i])] = ColumnBinding(rank_proj_idx, col);
+				}
+			} else {
+				order_remap[HashBinding(filter_bindings[i])] = ColumnBinding(rank_proj_idx, col);
 			}
-		} else {
-			order_remap[HashBinding(filter_bindings[i])] = ColumnBinding(noised_proj_idx, noised_col_idx);
 		}
 	}
 
-	auto noised_proj = make_uniq<LogicalProjection>(noised_proj_idx, std::move(noised_proj_exprs));
-	noised_proj->children.push_back(std::move(filter_op));
-	noised_proj->ResolveOperatorTypes();
+	auto rank_proj = make_uniq<LogicalProjection>(rank_proj_idx, std::move(rank_proj_exprs));
+	rank_proj->children.push_back(std::move(filter_op));
+	rank_proj->ResolveOperatorTypes();
 
-	// ---- Step 2d: Create FinalTopN above NoisedProj ----
-	// Remap original ORDER BY expressions to reference NoisedProj columns
+	// ---- Step 2d: Create FinalTopN above RankProj ----
+	// ORDER BY references pac_mean columns (deterministic, privacy-safe ranking)
 	vector<BoundOrderByNode> final_orders;
 	for (auto &order : ctx.topn->orders) {
 		auto expr = order.expression->Copy();
-		std::function<void(unique_ptr<Expression> &)> RemapToNoised = [&](unique_ptr<Expression> &e) {
+		std::function<void(unique_ptr<Expression> &)> RemapToRank = [&](unique_ptr<Expression> &e) {
 			if (e->type == ExpressionType::BOUND_COLUMN_REF) {
 				auto &ref = e->Cast<BoundColumnRefExpression>();
 				auto it = order_remap.find(HashBinding(ref.binding));
 				if (it != order_remap.end()) {
 					ref.binding = it->second;
-					// Update return type to match NoisedProj output
-					auto noised_bindings = noised_proj->GetColumnBindings();
-					for (idx_t ni = 0; ni < noised_bindings.size(); ni++) {
-						if (noised_bindings[ni] == it->second && ni < noised_proj->types.size()) {
-							ref.return_type = noised_proj->types[ni];
+					// Update return type to match RankProj output
+					auto rank_bindings = rank_proj->GetColumnBindings();
+					for (idx_t ni = 0; ni < rank_bindings.size(); ni++) {
+						if (rank_bindings[ni] == it->second && ni < rank_proj->types.size()) {
+							ref.return_type = rank_proj->types[ni];
 							break;
 						}
 					}
 				}
 			}
-			ExpressionIterator::EnumerateChildren(*e, RemapToNoised);
+			ExpressionIterator::EnumerateChildren(*e, RemapToRank);
 		};
-		RemapToNoised(expr);
+		RemapToRank(expr);
 		final_orders.push_back(BoundOrderByNode(order.type, order.null_order, std::move(expr)));
 	}
 
 	auto final_topn = make_uniq<LogicalTopN>(std::move(final_orders), ctx.topn->limit, ctx.topn->offset);
-	final_topn->children.push_back(std::move(noised_proj));
+	final_topn->children.push_back(std::move(rank_proj));
 	final_topn->ResolveOperatorTypes();
 
+	// ---- Step 2e: Create NoisedProj above FinalTopN ----
+	// Now that FinalTopN has selected the top K rows by pac_mean ranking,
+	// apply pac_noised to raw counters for privacy-safe output values.
+	// Output column order: PASSTHROUGH cols, then pac_noised(counters) for each PAC agg.
+	// (pac_mean and raw counters/keyhash are stripped from final output.)
+	idx_t noised_proj_idx = binder.GenerateTableIndex();
+	vector<unique_ptr<Expression>> noised_proj_exprs;
+
+	// First pass: emit columns in the same logical order as the original query output.
+	// Iterate rank_specs and for each:
+	//   PASSTHROUGH → passthrough from FinalTopN
+	//   PAC_MEAN    → replace with pac_noised(counters, keyhash) cast to original type
+	//   PAC_COUNTERS → skip (consumed by pac_noised above)
+	//   KEYHASH     → skip (consumed by pac_noised above)
+	for (auto &spec : rank_specs) {
+		if (spec.kind == RankColKind::PASSTHROUGH) {
+			auto topn_binding = ColumnBinding(rank_proj_idx, spec.rank_col);
+			noised_proj_exprs.push_back(make_uniq<BoundColumnRefExpression>(spec.type, topn_binding));
+		} else if (spec.kind == RankColKind::PAC_MEAN) {
+			// Replace pac_mean with pac_noised(raw_counters, keyhash) for the final output
+			auto counters_it = pac_counters_rank_col.find(spec.pac_idx);
+			D_ASSERT(counters_it != pac_counters_rank_col.end());
+			auto counters_binding = ColumnBinding(rank_proj_idx, counters_it->second);
+			auto counters_ref = make_uniq<BoundColumnRefExpression>(list_type, counters_binding);
+
+			unique_ptr<Expression> keyhash_ref;
+			if (keyhash_rank_col != idx_t(-1)) {
+				auto keyhash_binding = ColumnBinding(rank_proj_idx, keyhash_rank_col);
+				keyhash_ref = make_uniq<BoundColumnRefExpression>(LogicalType::UBIGINT, keyhash_binding);
+			} else {
+				keyhash_ref = make_uniq<BoundConstantExpression>(Value::UBIGINT(~uint64_t(0)));
+			}
+
+			auto noised = input.optimizer.BindScalarFunction("pac_noised", std::move(counters_ref),
+			                                                 std::move(keyhash_ref));
+			auto &orig_type = pac_aggs[spec.pac_idx].original_type;
+			if (orig_type != noised->return_type) {
+				noised = BoundCastExpression::AddCastToType(input.context, std::move(noised), orig_type);
+			}
+			noised_proj_exprs.push_back(std::move(noised));
+		}
+		// PAC_COUNTERS and KEYHASH columns are not emitted in the final output
+	}
+
+	auto noised_proj = make_uniq<LogicalProjection>(noised_proj_idx, std::move(noised_proj_exprs));
+	noised_proj->children.push_back(std::move(final_topn));
+	noised_proj->ResolveOperatorTypes();
+
 	// Replace the original plan
-	plan = std::move(final_topn);
+	plan = std::move(noised_proj);
 
 #if PAC_DEBUG
-	PAC_DEBUG_PRINT("PACTopKRule: Successfully rewrote plan for per-world top-k ranking");
+	PAC_DEBUG_PRINT("PACTopKRule: Successfully rewrote plan with mean-rank + noised output");
 	PAC_DEBUG_PRINT(plan->ToString());
 #endif
 }


### PR DESCRIPTION
this version uses the gloabl mean across the 64 worlds (unnoised) to decide the top-k keys (with basically zero noise and 100% recall), and then we noise those keys' values.

again, claude is heavily used for this PR, so please check the code. thanks!