### PR TITLE
Add DP smooth sensitivity sample-median strategy

### DIFF
--- a/src/aggregates/dp_laplace_noise.cpp
+++ b/src/aggregates/dp_laplace_noise.cpp
@@ -105,13 +105,12 @@ static void DpSmoothMedianNoiseFunction(DataChunk &args, ExpressionState &state,
 
 	idx_t count = args.size();
 	auto &list_vec = args.data[0];
-	UnifiedVectorFormat list_data, epsilon_data, delta_data, affected_data, lower_data, upper_data;
+	UnifiedVectorFormat list_data, epsilon_data, delta_data, lower_data, upper_data;
 	list_vec.ToUnifiedFormat(count, list_data);
 	args.data[1].ToUnifiedFormat(count, epsilon_data);
 	args.data[2].ToUnifiedFormat(count, delta_data);
-	args.data[3].ToUnifiedFormat(count, affected_data);
-	args.data[4].ToUnifiedFormat(count, lower_data);
-	args.data[5].ToUnifiedFormat(count, upper_data);
+	args.data[3].ToUnifiedFormat(count, lower_data);
+	args.data[4].ToUnifiedFormat(count, upper_data);
 
 	auto &child_vec = ListVector::GetEntry(list_vec);
 	UnifiedVectorFormat child_data;
@@ -120,7 +119,6 @@ static void DpSmoothMedianNoiseFunction(DataChunk &args, ExpressionState &state,
 	auto list_entries = UnifiedVectorFormat::GetData<list_entry_t>(list_data);
 	auto epsilons = UnifiedVectorFormat::GetData<double>(epsilon_data);
 	auto deltas = UnifiedVectorFormat::GetData<double>(delta_data);
-	auto affected_values = UnifiedVectorFormat::GetData<int32_t>(affected_data);
 	auto lowers = UnifiedVectorFormat::GetData<double>(lower_data);
 	auto uppers = UnifiedVectorFormat::GetData<double>(upper_data);
 	auto result_data = FlatVector::GetData<double>(result);
@@ -130,12 +128,11 @@ static void DpSmoothMedianNoiseFunction(DataChunk &args, ExpressionState &state,
 		auto list_idx = list_data.sel->get_index(i);
 		auto eps_idx = epsilon_data.sel->get_index(i);
 		auto delta_idx = delta_data.sel->get_index(i);
-		auto affected_idx = affected_data.sel->get_index(i);
 		auto lower_idx = lower_data.sel->get_index(i);
 		auto upper_idx = upper_data.sel->get_index(i);
 		if (!list_data.validity.RowIsValid(list_idx) || !epsilon_data.validity.RowIsValid(eps_idx) ||
-		    !delta_data.validity.RowIsValid(delta_idx) || !affected_data.validity.RowIsValid(affected_idx) ||
-		    !lower_data.validity.RowIsValid(lower_idx) || !upper_data.validity.RowIsValid(upper_idx)) {
+		    !delta_data.validity.RowIsValid(delta_idx) || !lower_data.validity.RowIsValid(lower_idx) ||
+		    !upper_data.validity.RowIsValid(upper_idx)) {
 			result_validity.SetInvalid(i);
 			continue;
 		}
@@ -146,11 +143,10 @@ static void DpSmoothMedianNoiseFunction(DataChunk &args, ExpressionState &state,
 		}
 		double epsilon = epsilons[eps_idx];
 		double delta = deltas[delta_idx];
-		int affected = affected_values[affected_idx];
 		double lower = lowers[lower_idx];
 		double upper = uppers[upper_idx];
-		if (epsilon <= 0.0 || delta <= 0.0 || delta >= 0.5 || affected <= 0 || !std::isfinite(epsilon) ||
-		    !std::isfinite(delta) || !std::isfinite(lower) || !std::isfinite(upper) || lower > upper) {
+		if (epsilon <= 0.0 || delta <= 0.0 || delta >= 0.5 || !std::isfinite(epsilon) || !std::isfinite(delta) ||
+		    !std::isfinite(lower) || !std::isfinite(upper) || lower > upper) {
 			result_validity.SetInvalid(i);
 			continue;
 		}
@@ -168,7 +164,7 @@ static void DpSmoothMedianNoiseFunction(DataChunk &args, ExpressionState &state,
 			continue;
 		}
 		double beta = epsilon / (2.0 * std::log(2.0 / delta));
-		double smooth = SmoothMedianSensitivity(values, lower, upper, std::min(affected, 63), beta);
+		double smooth = SmoothMedianSensitivity(values, lower, upper, DP_SAMPLE_DRAWS, beta);
 		result_data[i] = median + LaplaceNoise((2.0 * smooth) / epsilon, seed ^ (entry.offset * PAC_MAGIC_HASH));
 	}
 }
@@ -176,8 +172,7 @@ static void DpSmoothMedianNoiseFunction(DataChunk &args, ExpressionState &state,
 void RegisterDpSmoothMedianNoiseFunction(ExtensionLoader &loader) {
 	auto list_type = LogicalType::LIST(PacFloatLogicalType());
 	ScalarFunction fn("dp_smooth_median_noise",
-	                  {list_type, LogicalType::DOUBLE, LogicalType::DOUBLE, LogicalType::INTEGER, LogicalType::DOUBLE,
-	                   LogicalType::DOUBLE},
+	                  {list_type, LogicalType::DOUBLE, LogicalType::DOUBLE, LogicalType::DOUBLE, LogicalType::DOUBLE},
 	                  LogicalType::DOUBLE, DpSmoothMedianNoiseFunction);
 	CreateScalarFunctionInfo info(fn);
 	FunctionDescription desc;

--- a/src/aggregates/dp_laplace_noise.cpp
+++ b/src/aggregates/dp_laplace_noise.cpp
@@ -63,17 +63,27 @@ static double LaplaceNoise(double scale, uint64_t seed) {
 	return -scale * sign * std::log(std::max(1e-300, 1.0 - 2.0 * std::abs(u)));
 }
 
-static double SmoothMedianSensitivity(const std::array<double, 64> &values, double lower, double upper, int affected,
-                                      double beta) {
-	int median_idx = 31;
+static double MedianLocalSensitivity(const std::array<double, 64> &values, double lower, double upper,
+                                     int changed_lanes) {
+	const int median_idx = 31;
+	int lo_idx = median_idx - changed_lanes + 1;
+	int hi_idx = median_idx + changed_lanes;
+	double lo = lo_idx >= 0 ? values[lo_idx] : lower;
+	double hi = hi_idx < static_cast<int>(values.size()) ? values[hi_idx] : upper;
+	return std::max(0.0, hi - lo);
+}
+
+static double SmoothMedianSensitivity(const std::array<double, 64> &values, double lower, double upper,
+                                      int affected_lanes_per_pu, double beta) {
+	int step_size = std::max(1, affected_lanes_per_pu);
 	double smooth = 0.0;
-	for (int k = 0; k <= affected; k++) {
-		int lo_idx = median_idx - k;
-		int hi_idx = median_idx + 1 + k;
-		double lo = lo_idx >= 0 ? values[lo_idx] : lower;
-		double hi = hi_idx < static_cast<int>(values.size()) ? values[hi_idx] : upper;
-		double local = std::max(0.0, hi - lo);
-		smooth = std::max(smooth, local * std::exp(-beta * static_cast<double>(k)));
+	for (int distance = 0;; distance++) {
+		int changed_lanes = step_size * (distance + 1);
+		double local = MedianLocalSensitivity(values, lower, upper, changed_lanes);
+		smooth = std::max(smooth, local * std::exp(-beta * static_cast<double>(distance)));
+		if (changed_lanes >= static_cast<int>(values.size())) {
+			break;
+		}
 	}
 	return smooth;
 }

--- a/src/aggregates/dp_laplace_noise.cpp
+++ b/src/aggregates/dp_laplace_noise.cpp
@@ -3,6 +3,8 @@
 #include "duckdb/parser/parsed_data/create_scalar_function_info.hpp"
 #include "duckdb/function/scalar_function.hpp"
 
+#include <algorithm>
+#include <array>
 #include <cmath>
 #include <random>
 
@@ -46,6 +48,130 @@ void RegisterDpLaplaceNoiseFunction(ExtensionLoader &loader) {
 	CreateScalarFunctionInfo info(fn);
 	FunctionDescription desc;
 	desc.description = "Adds Laplace(0, scale) noise to a value for elastic-sensitivity DP.";
+	info.descriptions.push_back(std::move(desc));
+	loader.RegisterFunction(std::move(info));
+}
+
+static double LaplaceNoise(double scale, uint64_t seed) {
+	if (scale <= 0.0 || !std::isfinite(scale)) {
+		return 0.0;
+	}
+	std::mt19937_64 gen(seed);
+	std::uniform_real_distribution<double> uni(-0.5, 0.5);
+	double u = uni(gen);
+	double sign = (u < 0.0) ? -1.0 : 1.0;
+	return -scale * sign * std::log(std::max(1e-300, 1.0 - 2.0 * std::abs(u)));
+}
+
+static double SmoothMedianSensitivity(const std::array<double, 64> &values, double lower, double upper, int affected,
+                                      double beta) {
+	int median_idx = 31;
+	double smooth = 0.0;
+	for (int k = 0; k <= affected; k++) {
+		int lo_idx = median_idx - k;
+		int hi_idx = median_idx + 1 + k;
+		double lo = lo_idx >= 0 ? values[lo_idx] : lower;
+		double hi = hi_idx < static_cast<int>(values.size()) ? values[hi_idx] : upper;
+		double local = std::max(0.0, hi - lo);
+		smooth = std::max(smooth, local * std::exp(-beta * static_cast<double>(k)));
+	}
+	return smooth;
+}
+
+static void DpSmoothMedianNoiseFunction(DataChunk &args, ExpressionState &state, Vector &result) {
+	auto &context = state.GetContext();
+	Value seed_val;
+	uint64_t seed = (context.TryGetCurrentSetting("privacy_seed", seed_val) && !seed_val.IsNull())
+	                    ? uint64_t(seed_val.GetValue<int64_t>())
+	                    : uint64_t(std::random_device {}());
+	if (seed_val.IsNull()) {
+		seed ^= PAC_MAGIC_HASH * static_cast<uint64_t>(context.ActiveTransaction().GetActiveQuery());
+	}
+	bool noise_enabled = true;
+	Value noise_val;
+	if (context.TryGetCurrentSetting("privacy_noise", noise_val) && !noise_val.IsNull()) {
+		noise_enabled = noise_val.GetValue<bool>();
+	}
+
+	idx_t count = args.size();
+	auto &list_vec = args.data[0];
+	UnifiedVectorFormat list_data, epsilon_data, delta_data, affected_data, lower_data, upper_data;
+	list_vec.ToUnifiedFormat(count, list_data);
+	args.data[1].ToUnifiedFormat(count, epsilon_data);
+	args.data[2].ToUnifiedFormat(count, delta_data);
+	args.data[3].ToUnifiedFormat(count, affected_data);
+	args.data[4].ToUnifiedFormat(count, lower_data);
+	args.data[5].ToUnifiedFormat(count, upper_data);
+
+	auto &child_vec = ListVector::GetEntry(list_vec);
+	UnifiedVectorFormat child_data;
+	child_vec.ToUnifiedFormat(ListVector::GetListSize(list_vec), child_data);
+	auto child_values = UnifiedVectorFormat::GetData<PAC_FLOAT>(child_data);
+	auto list_entries = UnifiedVectorFormat::GetData<list_entry_t>(list_data);
+	auto epsilons = UnifiedVectorFormat::GetData<double>(epsilon_data);
+	auto deltas = UnifiedVectorFormat::GetData<double>(delta_data);
+	auto affected_values = UnifiedVectorFormat::GetData<int32_t>(affected_data);
+	auto lowers = UnifiedVectorFormat::GetData<double>(lower_data);
+	auto uppers = UnifiedVectorFormat::GetData<double>(upper_data);
+	auto result_data = FlatVector::GetData<double>(result);
+	auto &result_validity = FlatVector::Validity(result);
+
+	for (idx_t i = 0; i < count; i++) {
+		auto list_idx = list_data.sel->get_index(i);
+		auto eps_idx = epsilon_data.sel->get_index(i);
+		auto delta_idx = delta_data.sel->get_index(i);
+		auto affected_idx = affected_data.sel->get_index(i);
+		auto lower_idx = lower_data.sel->get_index(i);
+		auto upper_idx = upper_data.sel->get_index(i);
+		if (!list_data.validity.RowIsValid(list_idx) || !epsilon_data.validity.RowIsValid(eps_idx) ||
+		    !delta_data.validity.RowIsValid(delta_idx) || !affected_data.validity.RowIsValid(affected_idx) ||
+		    !lower_data.validity.RowIsValid(lower_idx) || !upper_data.validity.RowIsValid(upper_idx)) {
+			result_validity.SetInvalid(i);
+			continue;
+		}
+		auto &entry = list_entries[list_idx];
+		if (entry.length != 64) {
+			result_validity.SetInvalid(i);
+			continue;
+		}
+		double epsilon = epsilons[eps_idx];
+		double delta = deltas[delta_idx];
+		int affected = affected_values[affected_idx];
+		double lower = lowers[lower_idx];
+		double upper = uppers[upper_idx];
+		if (epsilon <= 0.0 || delta <= 0.0 || delta >= 0.5 || affected <= 0 || !std::isfinite(epsilon) ||
+		    !std::isfinite(delta) || !std::isfinite(lower) || !std::isfinite(upper) || lower > upper) {
+			result_validity.SetInvalid(i);
+			continue;
+		}
+		std::array<double, 64> values;
+		for (idx_t j = 0; j < 64; j++) {
+			auto child_idx = child_data.sel->get_index(entry.offset + j);
+			double value =
+			    child_data.validity.RowIsValid(child_idx) ? static_cast<double>(child_values[child_idx]) : 0.0;
+			values[j] = std::min(std::max(value, lower), upper);
+		}
+		std::sort(values.begin(), values.end());
+		double median = values[31];
+		if (!noise_enabled) {
+			result_data[i] = median;
+			continue;
+		}
+		double beta = epsilon / (2.0 * std::log(2.0 / delta));
+		double smooth = SmoothMedianSensitivity(values, lower, upper, std::min(affected, 63), beta);
+		result_data[i] = median + LaplaceNoise((2.0 * smooth) / epsilon, seed ^ (entry.offset * PAC_MAGIC_HASH));
+	}
+}
+
+void RegisterDpSmoothMedianNoiseFunction(ExtensionLoader &loader) {
+	auto list_type = LogicalType::LIST(PacFloatLogicalType());
+	ScalarFunction fn("dp_smooth_median_noise",
+	                  {list_type, LogicalType::DOUBLE, LogicalType::DOUBLE, LogicalType::INTEGER, LogicalType::DOUBLE,
+	                   LogicalType::DOUBLE},
+	                  LogicalType::DOUBLE, DpSmoothMedianNoiseFunction);
+	CreateScalarFunctionInfo info(fn);
+	FunctionDescription desc;
+	desc.description = "Applies smooth-sensitivity median release to 64 sample counters.";
 	info.descriptions.push_back(std::move(desc));
 	loader.RegisterFunction(std::move(info));
 }

--- a/src/aggregates/dp_laplace_noise.cpp
+++ b/src/aggregates/dp_laplace_noise.cpp
@@ -63,27 +63,25 @@ static double LaplaceNoise(double scale, uint64_t seed) {
 	return -scale * sign * std::log(std::max(1e-300, 1.0 - 2.0 * std::abs(u)));
 }
 
-static double MedianLocalSensitivity(const std::array<double, 64> &values, double lower, double upper,
-                                     int changed_lanes) {
+static double MedianLocalSensitivity(const std::array<double, 64> &values, int changed_lanes) {
 	const int median_idx = 31;
-	int lo_idx = median_idx - changed_lanes + 1;
+	int lo_idx = median_idx - changed_lanes;
 	int hi_idx = median_idx + changed_lanes;
-	double lo = lo_idx >= 0 ? values[lo_idx] : lower;
-	double hi = hi_idx < static_cast<int>(values.size()) ? values[hi_idx] : upper;
-	return std::max(0.0, hi - lo);
+	D_ASSERT(lo_idx >= 0);
+	D_ASSERT(hi_idx < static_cast<int>(values.size()));
+	return std::max(0.0, values[hi_idx] - values[lo_idx]);
 }
 
-static double SmoothMedianSensitivity(const std::array<double, 64> &values, double lower, double upper,
-                                      int affected_lanes_per_pu, double beta) {
-	int step_size = std::max(1, affected_lanes_per_pu);
+static double SmoothMedianSensitivity(const std::array<double, 64> &values, double beta) {
+	const int step_size = DP_SAMPLE_DRAWS;
 	double smooth = 0.0;
-	for (int distance = 0;; distance++) {
+	for (int distance = 0; distance < 64; distance++) {
 		int changed_lanes = step_size * (distance + 1);
-		double local = MedianLocalSensitivity(values, lower, upper, changed_lanes);
-		smooth = std::max(smooth, local * std::exp(-beta * static_cast<double>(distance)));
-		if (changed_lanes >= static_cast<int>(values.size())) {
+		if (changed_lanes >= 32) {
 			break;
 		}
+		double local = MedianLocalSensitivity(values, changed_lanes);
+		smooth = std::max(smooth, local * std::exp(-beta * static_cast<double>(distance)));
 	}
 	return smooth;
 }
@@ -105,12 +103,10 @@ static void DpSmoothMedianNoiseFunction(DataChunk &args, ExpressionState &state,
 
 	idx_t count = args.size();
 	auto &list_vec = args.data[0];
-	UnifiedVectorFormat list_data, epsilon_data, delta_data, lower_data, upper_data;
+	UnifiedVectorFormat list_data, epsilon_data, delta_data;
 	list_vec.ToUnifiedFormat(count, list_data);
 	args.data[1].ToUnifiedFormat(count, epsilon_data);
 	args.data[2].ToUnifiedFormat(count, delta_data);
-	args.data[3].ToUnifiedFormat(count, lower_data);
-	args.data[4].ToUnifiedFormat(count, upper_data);
 
 	auto &child_vec = ListVector::GetEntry(list_vec);
 	UnifiedVectorFormat child_data;
@@ -119,8 +115,6 @@ static void DpSmoothMedianNoiseFunction(DataChunk &args, ExpressionState &state,
 	auto list_entries = UnifiedVectorFormat::GetData<list_entry_t>(list_data);
 	auto epsilons = UnifiedVectorFormat::GetData<double>(epsilon_data);
 	auto deltas = UnifiedVectorFormat::GetData<double>(delta_data);
-	auto lowers = UnifiedVectorFormat::GetData<double>(lower_data);
-	auto uppers = UnifiedVectorFormat::GetData<double>(upper_data);
 	auto result_data = FlatVector::GetData<double>(result);
 	auto &result_validity = FlatVector::Validity(result);
 
@@ -128,11 +122,8 @@ static void DpSmoothMedianNoiseFunction(DataChunk &args, ExpressionState &state,
 		auto list_idx = list_data.sel->get_index(i);
 		auto eps_idx = epsilon_data.sel->get_index(i);
 		auto delta_idx = delta_data.sel->get_index(i);
-		auto lower_idx = lower_data.sel->get_index(i);
-		auto upper_idx = upper_data.sel->get_index(i);
 		if (!list_data.validity.RowIsValid(list_idx) || !epsilon_data.validity.RowIsValid(eps_idx) ||
-		    !delta_data.validity.RowIsValid(delta_idx) || !lower_data.validity.RowIsValid(lower_idx) ||
-		    !upper_data.validity.RowIsValid(upper_idx)) {
+		    !delta_data.validity.RowIsValid(delta_idx)) {
 			result_validity.SetInvalid(i);
 			continue;
 		}
@@ -143,10 +134,7 @@ static void DpSmoothMedianNoiseFunction(DataChunk &args, ExpressionState &state,
 		}
 		double epsilon = epsilons[eps_idx];
 		double delta = deltas[delta_idx];
-		double lower = lowers[lower_idx];
-		double upper = uppers[upper_idx];
-		if (epsilon <= 0.0 || delta <= 0.0 || delta >= 0.5 || !std::isfinite(epsilon) || !std::isfinite(delta) ||
-		    !std::isfinite(lower) || !std::isfinite(upper) || lower > upper) {
+		if (epsilon <= 0.0 || delta <= 0.0 || delta >= 0.5 || !std::isfinite(epsilon) || !std::isfinite(delta)) {
 			result_validity.SetInvalid(i);
 			continue;
 		}
@@ -155,7 +143,7 @@ static void DpSmoothMedianNoiseFunction(DataChunk &args, ExpressionState &state,
 			auto child_idx = child_data.sel->get_index(entry.offset + j);
 			double value =
 			    child_data.validity.RowIsValid(child_idx) ? static_cast<double>(child_values[child_idx]) : 0.0;
-			values[j] = std::min(std::max(value, lower), upper);
+			values[j] = value;
 		}
 		std::sort(values.begin(), values.end());
 		double median = values[31];
@@ -164,15 +152,14 @@ static void DpSmoothMedianNoiseFunction(DataChunk &args, ExpressionState &state,
 			continue;
 		}
 		double beta = epsilon / (2.0 * std::log(2.0 / delta));
-		double smooth = SmoothMedianSensitivity(values, lower, upper, DP_SAMPLE_DRAWS, beta);
+		double smooth = SmoothMedianSensitivity(values, beta);
 		result_data[i] = median + LaplaceNoise((2.0 * smooth) / epsilon, seed ^ (entry.offset * PAC_MAGIC_HASH));
 	}
 }
 
 void RegisterDpSmoothMedianNoiseFunction(ExtensionLoader &loader) {
 	auto list_type = LogicalType::LIST(PacFloatLogicalType());
-	ScalarFunction fn("dp_smooth_median_noise",
-	                  {list_type, LogicalType::DOUBLE, LogicalType::DOUBLE, LogicalType::DOUBLE, LogicalType::DOUBLE},
+	ScalarFunction fn("dp_smooth_median_noise", {list_type, LogicalType::DOUBLE, LogicalType::DOUBLE},
 	                  LogicalType::DOUBLE, DpSmoothMedianNoiseFunction);
 	CreateScalarFunctionInfo info(fn);
 	FunctionDescription desc;

--- a/src/aggregates/pac_clip_sum.cpp
+++ b/src/aggregates/pac_clip_sum.cpp
@@ -5,14 +5,26 @@
 #include <cmath>
 
 namespace duckdb {
+struct PacIdentityHash {
+	static inline uint64_t Transform(uint64_t key_hash) {
+		return key_hash;
+	}
+};
+
+struct PacDpSampleHash {
+	static inline uint64_t Transform(uint64_t key_hash) {
+		return DpSampleHash(key_hash);
+	}
+};
 
 // ============================================================================
 // Inner state update: add one unsigned value to the state
 // ============================================================================
 template <int NL = CLIP_NUM_LEVELS_64>
-AUTOVECTORIZE inline void PacClipSumUpdateOneInternal(PacClipSumIntState<NL> &state, uint64_t key_hash, uint64_t value,
+AUTOVECTORIZE inline void PacClipSumUpdateOneInternal(PacClipSumIntState<NL> &state, uint64_t counter_hash,
+                                                      uint64_t support_hash, uint64_t value,
                                                       ArenaAllocator &allocator) {
-	state.key_hash |= key_hash;
+	state.key_hash |= counter_hash;
 
 	int level = PacClipSumIntState<NL>::GetLevel(value);
 	uint64_t shift = level << 1;
@@ -22,13 +34,19 @@ AUTOVECTORIZE inline void PacClipSumUpdateOneInternal(PacClipSumIntState<NL> &st
 	uint64_t *buf = state.levels[level];
 
 	// Set bitmap bit
-	buf[17] |= (1ULL << (key_hash >> 58));
+	buf[17] |= (1ULL << (support_hash >> 58));
 
 	// Update exact_count (may cascade top 4 bits to overflow)
 	state.AddToExactCount(buf, shifted_val, allocator);
 
 	// Add to SWAR counters
-	Pac2AddToTotalsSWAR16(buf, shifted_val, key_hash);
+	Pac2AddToTotalsSWAR16(buf, shifted_val, counter_hash);
+}
+
+template <int NL = CLIP_NUM_LEVELS_64>
+AUTOVECTORIZE inline void PacClipSumUpdateOneInternal(PacClipSumIntState<NL> &state, uint64_t key_hash, uint64_t value,
+                                                      ArenaAllocator &allocator) {
+	PacClipSumUpdateOneInternal(state, key_hash, key_hash, value, allocator);
 }
 
 // Overload for hugeint_t
@@ -72,17 +90,20 @@ AUTOVECTORIZE inline void PacClipSumUpdateOneInternal(PacClipSumIntState<NL> &st
 // Value routing: two-sided (pos/neg) dispatch
 // ============================================================================
 // Route a uint64_t value — when SIGNED, the bits represent a signed int64_t (two's complement)
-template <int NL = CLIP_NUM_LEVELS_64, bool SIGNED = true>
-inline void PacClipSumRouteValue(PacClipSumStateWrapper<NL> &wrapper, PacClipSumIntState<NL> *pos_state, uint64_t hash,
-                                 uint64_t value, ArenaAllocator &a) {
-	if (DUCKDB_LIKELY(hash)) {
+template <int NL = CLIP_NUM_LEVELS_64, bool SIGNED = true, class HASH_TRANSFORM = PacIdentityHash>
+inline void PacClipSumRouteValue(PacClipSumStateWrapper<NL> &wrapper, PacClipSumIntState<NL> *pos_state,
+                                 uint64_t support_hash, uint64_t value, ArenaAllocator &a) {
+	if (DUCKDB_LIKELY(support_hash)) {
+		uint64_t counter_hash = HASH_TRANSFORM::Transform(support_hash);
 		int64_t sval = static_cast<int64_t>(value); // reinterpret bits as signed
 		if (SIGNED && sval < 0) {
+			uint64_t abs_value =
+			    sval == INT64_MIN ? static_cast<uint64_t>(INT64_MAX) + 1ULL : static_cast<uint64_t>(-sval);
 			auto *neg = wrapper.EnsureNegState(a);
-			PacClipSumUpdateOneInternal(*neg, hash, static_cast<uint64_t>(-sval), a);
+			PacClipSumUpdateOneInternal(*neg, counter_hash, support_hash, abs_value, a);
 			neg->update_count++;
 		} else {
-			PacClipSumUpdateOneInternal(*pos_state, hash, value, a);
+			PacClipSumUpdateOneInternal(*pos_state, counter_hash, support_hash, value, a);
 			pos_state->update_count++;
 		}
 	}
@@ -126,13 +147,13 @@ inline void PacClipSumRouteHugeint(PacClipSumStateWrapper<NL> &wrapper, PacClipS
 // ============================================================================
 // Buffer flush
 // ============================================================================
-template <int NL = CLIP_NUM_LEVELS_64, bool SIGNED = true>
+template <int NL = CLIP_NUM_LEVELS_64, bool SIGNED = true, class HASH_TRANSFORM = PacIdentityHash>
 inline void PacClipSumFlushBuffer(PacClipSumStateWrapper<NL> &src, PacClipSumStateWrapper<NL> &dst, ArenaAllocator &a) {
 	uint64_t cnt = src.n_buffered & PacClipSumStateWrapper<NL>::BUF_MASK;
 	if (cnt > 0) {
 		auto *dst_state = dst.EnsureState(a);
 		for (uint64_t i = 0; i < cnt; i++) {
-			PacClipSumRouteValue<NL, SIGNED>(dst, dst_state, src.hash_buf[i], src.val_buf[i], a);
+			PacClipSumRouteValue<NL, SIGNED, HASH_TRANSFORM>(dst, dst_state, src.hash_buf[i], src.val_buf[i], a);
 		}
 		src.n_buffered &= ~PacClipSumStateWrapper<NL>::BUF_MASK;
 	}
@@ -141,16 +162,17 @@ inline void PacClipSumFlushBuffer(PacClipSumStateWrapper<NL> &src, PacClipSumSta
 // ============================================================================
 // Buffered update
 // ============================================================================
-template <int NL = CLIP_NUM_LEVELS_64, bool SIGNED = true, typename ValueT = uint64_t>
+template <int NL = CLIP_NUM_LEVELS_64, bool SIGNED = true, typename ValueT = uint64_t,
+          class HASH_TRANSFORM = PacIdentityHash>
 AUTOVECTORIZE inline void PacClipSumUpdateOne(PacClipSumStateWrapper<NL> &agg, uint64_t key_hash, ValueT value,
                                               ArenaAllocator &a) {
 	uint64_t cnt = agg.n_buffered & PacClipSumStateWrapper<NL>::BUF_MASK;
 	if (DUCKDB_UNLIKELY(cnt == PacClipSumStateWrapper<NL>::BUF_SIZE)) {
 		auto *dst_state = agg.EnsureState(a);
 		for (int i = 0; i < PacClipSumStateWrapper<NL>::BUF_SIZE; i++) {
-			PacClipSumRouteValue<NL, SIGNED>(agg, dst_state, agg.hash_buf[i], agg.val_buf[i], a);
+			PacClipSumRouteValue<NL, SIGNED, HASH_TRANSFORM>(agg, dst_state, agg.hash_buf[i], agg.val_buf[i], a);
 		}
-		PacClipSumRouteValue<NL, SIGNED>(agg, dst_state, key_hash, static_cast<uint64_t>(value), a);
+		PacClipSumRouteValue<NL, SIGNED, HASH_TRANSFORM>(agg, dst_state, key_hash, static_cast<uint64_t>(value), a);
 		agg.n_buffered &= ~PacClipSumStateWrapper<NL>::BUF_MASK;
 	} else {
 		agg.val_buf[cnt] = static_cast<uint64_t>(value);
@@ -171,7 +193,8 @@ inline void PacClipSumUpdateOne(PacClipSumStateWrapper<NL> &agg, uint64_t key_ha
 // ============================================================================
 // Vectorized Update and ScatterUpdate
 // ============================================================================
-template <int NL = CLIP_NUM_LEVELS_64, bool SIGNED = true, class VALUE_TYPE = uint64_t, class INPUT_TYPE = uint64_t>
+template <int NL = CLIP_NUM_LEVELS_64, bool SIGNED = true, class VALUE_TYPE = uint64_t, class INPUT_TYPE = uint64_t,
+          class HASH_TRANSFORM = PacIdentityHash>
 static void PacClipSumUpdate(Vector inputs[], PacClipSumStateWrapper<NL> &state, idx_t count,
                              ArenaAllocator &allocator) {
 	UnifiedVectorFormat hash_data, value_data;
@@ -184,8 +207,8 @@ static void PacClipSumUpdate(Vector inputs[], PacClipSumStateWrapper<NL> &state,
 		for (idx_t i = 0; i < count; i++) {
 			auto h_idx = hash_data.sel->get_index(i);
 			auto v_idx = value_data.sel->get_index(i);
-			PacClipSumUpdateOne<NL, SIGNED>(state, hashes[h_idx], ConvertValue<VALUE_TYPE>::convert(values[v_idx]),
-			                                allocator);
+			PacClipSumUpdateOne<NL, SIGNED, VALUE_TYPE, HASH_TRANSFORM>(
+			    state, hashes[h_idx], ConvertValue<VALUE_TYPE>::convert(values[v_idx]), allocator);
 		}
 	} else {
 		for (idx_t i = 0; i < count; i++) {
@@ -194,13 +217,14 @@ static void PacClipSumUpdate(Vector inputs[], PacClipSumStateWrapper<NL> &state,
 			if (!hash_data.validity.RowIsValid(h_idx) || !value_data.validity.RowIsValid(v_idx)) {
 				continue;
 			}
-			PacClipSumUpdateOne<NL, SIGNED>(state, hashes[h_idx], ConvertValue<VALUE_TYPE>::convert(values[v_idx]),
-			                                allocator);
+			PacClipSumUpdateOne<NL, SIGNED, VALUE_TYPE, HASH_TRANSFORM>(
+			    state, hashes[h_idx], ConvertValue<VALUE_TYPE>::convert(values[v_idx]), allocator);
 		}
 	}
 }
 
-template <int NL = CLIP_NUM_LEVELS_64, bool SIGNED = true, class VALUE_TYPE = uint64_t, class INPUT_TYPE = uint64_t>
+template <int NL = CLIP_NUM_LEVELS_64, bool SIGNED = true, class VALUE_TYPE = uint64_t, class INPUT_TYPE = uint64_t,
+          class HASH_TRANSFORM = PacIdentityHash>
 static void PacClipSumScatterUpdate(Vector inputs[], Vector &states, idx_t count, ArenaAllocator &allocator) {
 	UnifiedVectorFormat hash_data, value_data, sdata;
 	inputs[0].ToUnifiedFormat(count, hash_data);
@@ -218,8 +242,8 @@ static void PacClipSumScatterUpdate(Vector inputs[], Vector &states, idx_t count
 		if (!hash_data.validity.RowIsValid(h_idx) || !value_data.validity.RowIsValid(v_idx)) {
 			continue;
 		}
-		PacClipSumUpdateOne<NL, SIGNED>(*state, hashes[h_idx], ConvertValue<VALUE_TYPE>::convert(values[v_idx]),
-		                                allocator);
+		PacClipSumUpdateOne<NL, SIGNED, VALUE_TYPE, HASH_TRANSFORM>(
+		    *state, hashes[h_idx], ConvertValue<VALUE_TYPE>::convert(values[v_idx]), allocator);
 	}
 }
 
@@ -377,7 +401,7 @@ static void PacClipSumScatterUpdateUHugeInt(Vector inputs[], AggregateInputData 
 // ============================================================================
 // Float/Double update: scale to int64, route through signed path
 // ============================================================================
-template <typename FLOAT_TYPE, int SHIFT>
+template <typename FLOAT_TYPE, int SHIFT, class HASH_TRANSFORM = PacIdentityHash>
 static void PacClipSumUpdateFloat(Vector inputs[], AggregateInputData &aggr, idx_t, data_ptr_t state_p, idx_t count) {
 	auto &state = *reinterpret_cast<PacClipSumStateWrapper<> *>(state_p);
 	UnifiedVectorFormat hash_data, value_data;
@@ -390,7 +414,7 @@ static void PacClipSumUpdateFloat(Vector inputs[], AggregateInputData &aggr, idx
 		for (idx_t i = 0; i < count; i++) {
 			auto h_idx = hash_data.sel->get_index(i);
 			auto v_idx = value_data.sel->get_index(i);
-			PacClipSumUpdateOne<CLIP_NUM_LEVELS_64, true>(
+			PacClipSumUpdateOne<CLIP_NUM_LEVELS_64, true, int64_t, HASH_TRANSFORM>(
 			    state, hashes[h_idx], ScaleFloatToInt64<FLOAT_TYPE, SHIFT>(values[v_idx]), aggr.allocator);
 		}
 	} else {
@@ -400,13 +424,13 @@ static void PacClipSumUpdateFloat(Vector inputs[], AggregateInputData &aggr, idx
 			if (!hash_data.validity.RowIsValid(h_idx) || !value_data.validity.RowIsValid(v_idx)) {
 				continue;
 			}
-			PacClipSumUpdateOne<CLIP_NUM_LEVELS_64, true>(
+			PacClipSumUpdateOne<CLIP_NUM_LEVELS_64, true, int64_t, HASH_TRANSFORM>(
 			    state, hashes[h_idx], ScaleFloatToInt64<FLOAT_TYPE, SHIFT>(values[v_idx]), aggr.allocator);
 		}
 	}
 }
 
-template <typename FLOAT_TYPE, int SHIFT>
+template <typename FLOAT_TYPE, int SHIFT, class HASH_TRANSFORM = PacIdentityHash>
 static void PacClipSumScatterUpdateFloat(Vector inputs[], AggregateInputData &aggr, idx_t, Vector &states,
                                          idx_t count) {
 	UnifiedVectorFormat hash_data, value_data, sdata;
@@ -424,7 +448,7 @@ static void PacClipSumScatterUpdateFloat(Vector inputs[], AggregateInputData &ag
 		if (!hash_data.validity.RowIsValid(h_idx) || !value_data.validity.RowIsValid(v_idx)) {
 			continue;
 		}
-		PacClipSumUpdateOne<CLIP_NUM_LEVELS_64, true>(
+		PacClipSumUpdateOne<CLIP_NUM_LEVELS_64, true, int64_t, HASH_TRANSFORM>(
 		    *state, hashes[h_idx], ScaleFloatToInt64<FLOAT_TYPE, SHIFT>(values[v_idx]), aggr.allocator);
 	}
 }
@@ -447,17 +471,27 @@ static void PacClipSumScatterUpdateSingleDouble(Vector inputs[], AggregateInputD
 	PacClipSumScatterUpdateFloat<double, CLIP_DOUBLE_SHIFT>(inputs, aggr, n, states, count);
 }
 
+static void DpSampleClipSumUpdateDouble(Vector inputs[], AggregateInputData &aggr, idx_t, data_ptr_t state_p,
+                                        idx_t count) {
+	PacClipSumUpdateFloat<double, CLIP_DOUBLE_SHIFT, PacDpSampleHash>(inputs, aggr, 0, state_p, count);
+}
+
+static void DpSampleClipSumScatterUpdateDouble(Vector inputs[], AggregateInputData &aggr, idx_t, Vector &states,
+                                               idx_t count) {
+	PacClipSumScatterUpdateFloat<double, CLIP_DOUBLE_SHIFT, PacDpSampleHash>(inputs, aggr, 0, states, count);
+}
+
 // ============================================================================
 // Combine
 // ============================================================================
-template <int NL = CLIP_NUM_LEVELS_64>
+template <int NL = CLIP_NUM_LEVELS_64, class HASH_TRANSFORM = PacIdentityHash>
 AUTOVECTORIZE static void PacClipSumCombineInt(Vector &src, Vector &dst, idx_t count, ArenaAllocator &allocator) {
 	auto src_wrapper = FlatVector::GetData<PacClipSumStateWrapper<NL> *>(src);
 	auto dst_wrapper = FlatVector::GetData<PacClipSumStateWrapper<NL> *>(dst);
 
 	for (idx_t i = 0; i < count; i++) {
 		// Flush src's buffer into dst
-		PacClipSumFlushBuffer<NL, true>(*src_wrapper[i], *dst_wrapper[i], allocator);
+		PacClipSumFlushBuffer<NL, true, HASH_TRANSFORM>(*src_wrapper[i], *dst_wrapper[i], allocator);
 
 		auto *s = src_wrapper[i]->GetState();
 		if (!s) {
@@ -484,6 +518,9 @@ static void PacClipSumCombine(Vector &src, Vector &dst, AggregateInputData &aggr
 }
 static void PacClipSumCombine128(Vector &src, Vector &dst, AggregateInputData &aggr, idx_t count) {
 	PacClipSumCombineInt<CLIP_NUM_LEVELS>(src, dst, count, aggr.allocator);
+}
+static void DpSampleClipSumCombine(Vector &src, Vector &dst, AggregateInputData &aggr, idx_t count) {
+	PacClipSumCombineInt<CLIP_NUM_LEVELS_64, PacDpSampleHash>(src, dst, count, aggr.allocator);
 }
 
 // PacClipBindData is defined in pac_clip_aggr.hpp
@@ -586,10 +623,13 @@ static void PacClipSumNoisedFinalizeDouble(Vector &states, AggregateInputData &i
 	PacClipSumFinalize<CLIP_NUM_LEVELS_64, double, true>(states, input, result, count, offset);
 }
 
+enum class ClipCountersFinalizeMode : uint8_t { PAC, DP_SAMPLE };
+
 // ============================================================================
-// Counters finalize (LIST<FLOAT> output for pac_clip_sum)
+// Counters finalize (LIST<FLOAT> output for pac_clip_sum and dp_sample_clip_sum)
 // ============================================================================
-template <int NL = CLIP_NUM_LEVELS_64, bool SIGNED = true>
+template <int NL = CLIP_NUM_LEVELS_64, bool SIGNED = true,
+          ClipCountersFinalizeMode MODE = ClipCountersFinalizeMode::PAC>
 static void PacClipSumFinalizeCounters(Vector &states, AggregateInputData &input, Vector &result, idx_t count,
                                        idx_t offset) {
 	auto state_ptrs = FlatVector::GetData<PacClipSumStateWrapper<NL> *>(states);
@@ -598,8 +638,8 @@ static void PacClipSumFinalizeCounters(Vector &states, AggregateInputData &input
 	double correction = bind.correction;
 	double float_scale = bind.float_scale;
 	bool clip_scale = bind.clip_scale;
+	bool dp_sample = MODE == ClipCountersFinalizeMode::DP_SAMPLE;
 
-	// Result is LIST<FLOAT>
 	auto list_entries = FlatVector::GetData<list_entry_t>(result);
 	auto &child_vec = ListVector::GetEntry(result);
 
@@ -610,8 +650,11 @@ static void PacClipSumFinalizeCounters(Vector &states, AggregateInputData &input
 	auto child_data = FlatVector::GetData<PAC_FLOAT>(child_vec);
 
 	for (idx_t i = 0; i < count; i++) {
-		PacClipSumFlushBuffer<NL, SIGNED>(*state_ptrs[i], *state_ptrs[i], input.allocator);
-
+		if (dp_sample) {
+			PacClipSumFlushBuffer<NL, SIGNED, PacDpSampleHash>(*state_ptrs[i], *state_ptrs[i], input.allocator);
+		} else {
+			PacClipSumFlushBuffer<NL, SIGNED>(*state_ptrs[i], *state_ptrs[i], input.allocator);
+		}
 		list_entries[offset + i].offset = i * 64;
 		list_entries[offset + i].length = 64;
 
@@ -623,25 +666,36 @@ static void PacClipSumFinalizeCounters(Vector &states, AggregateInputData &input
 		if (pos) {
 			key_hash = pos->key_hash;
 			update_count = pos->update_count;
-			pos->GetTotals(buf, clip_support, clip_scale);
-
-			auto *neg = state_ptrs[i]->GetNegState();
-			if (neg) {
-				PAC_FLOAT neg_buf[64] = {0};
+			if (dp_sample) {
+				pos->GetTotals(buf, clip_support, false, true);
+			} else {
+				pos->GetTotals(buf, clip_support, clip_scale);
+			}
+		}
+		auto *neg = state_ptrs[i]->GetNegState();
+		if (neg) {
+			PAC_FLOAT neg_buf[64] = {0};
+			key_hash |= neg->key_hash;
+			update_count += neg->update_count;
+			if (dp_sample) {
+				neg->GetTotals(neg_buf, clip_support, false, true);
+			} else {
 				neg->GetTotals(neg_buf, clip_support, clip_scale);
-				key_hash |= neg->key_hash;
-				for (int j = 0; j < 64; j++) {
-					buf[j] -= neg_buf[j];
-				}
-				update_count += neg->update_count;
+			}
+			for (int j = 0; j < 64; j++) {
+				buf[j] -= neg_buf[j];
 			}
 		}
 
-		CheckPacSampleDiversity(key_hash, buf, update_count, "pac_clip_sum", bind);
+		if (!dp_sample) {
+			CheckPacSampleDiversity(key_hash, buf, update_count, "pac_clip_sum", bind);
+		}
 
 		idx_t base = i * 64;
 		for (int j = 0; j < 64; j++) {
-			if ((key_hash >> j) & 1ULL) {
+			if (dp_sample) {
+				child_data[base + j] = static_cast<PAC_FLOAT>(buf[j] * DP_SAMPLE_RESCALE / float_scale);
+			} else if ((key_hash >> j) & 1ULL) {
 				child_data[base + j] = static_cast<PAC_FLOAT>(buf[j] * 2.0 * correction / float_scale);
 			} else {
 				child_data[base + j] = 0.0;
@@ -667,6 +721,11 @@ static void PacClipSumFinalizeCountersSigned128(Vector &states, AggregateInputDa
 static void PacClipSumFinalizeCountersUnsigned128(Vector &states, AggregateInputData &input, Vector &result,
                                                   idx_t count, idx_t offset) {
 	PacClipSumFinalizeCounters<CLIP_NUM_LEVELS, false>(states, input, result, count, offset);
+}
+static void DpSampleClipSumFinalizeCounters(Vector &states, AggregateInputData &input, Vector &result, idx_t count,
+                                            idx_t offset) {
+	PacClipSumFinalizeCounters<CLIP_NUM_LEVELS_64, true, ClipCountersFinalizeMode::DP_SAMPLE>(states, input, result,
+	                                                                                          count, offset);
 }
 
 // ============================================================================
@@ -764,6 +823,19 @@ static unique_ptr<FunctionData> BindDecimalPacClipSum(ClientContext &ctx, Aggreg
 	function.arguments[1] = decimal_type;
 	// counters always return LIST<FLOAT>, no DECIMAL return type needed
 	return PacClipBind(ctx, function, args);
+}
+
+static unique_ptr<FunctionData> DpSampleClipSumBind(ClientContext &ctx, AggregateFunction &,
+                                                    vector<unique_ptr<Expression>> &) {
+	Value dc_val;
+	int clip_support = 0;
+	if (ctx.TryGetCurrentSetting("pac_clip_support", dc_val) && !dc_val.IsNull()) {
+		clip_support = static_cast<int>(dc_val.GetValue<int64_t>());
+	}
+	if (clip_support <= 0) {
+		throw InvalidInputException("dp_sample_clip_sum: pac_clip_support must be set to a positive value");
+	}
+	return make_uniq<PacClipBindData>(ctx, 0.0, 1.0, clip_support, CLIP_DOUBLE_SCALE, false);
 }
 
 // ============================================================================
@@ -962,6 +1034,21 @@ void RegisterPacNoisedClipSumCountFunctions(ExtensionLoader &loader) {
 	AddNoisedClipSumFcn(fcn_set, "pac_noised_clip_sumcount", LogicalType::BIGINT, LogicalType::BIGINT,
 	                    PacClipSumScatterUpdateBigInt, PacClipSumNoisedFinalizeBigInt, PacClipSumUpdateBigInt);
 	CreateAggregateFunctionInfo info(fcn_set);
+	loader.RegisterFunction(std::move(info));
+}
+
+void RegisterDpSampleClipSumFunctions(ExtensionLoader &loader) {
+	auto list_type = LogicalType::LIST(PacFloatLogicalType());
+	AggregateFunctionSet set("dp_sample_clip_sum");
+	set.AddFunction(AggregateFunction("dp_sample_clip_sum", {LogicalType::UBIGINT, LogicalType::DOUBLE}, list_type,
+	                                  PacClipSumStateSize, PacClipSumInitialize, DpSampleClipSumScatterUpdateDouble,
+	                                  DpSampleClipSumCombine, DpSampleClipSumFinalizeCounters,
+	                                  FunctionNullHandling::DEFAULT_NULL_HANDLING, DpSampleClipSumUpdateDouble,
+	                                  DpSampleClipSumBind));
+	CreateAggregateFunctionInfo info(set);
+	FunctionDescription desc;
+	desc.description = "[INTERNAL] Returns 64 sample-median DP counters with smooth group-level clipping.";
+	info.descriptions.push_back(std::move(desc));
 	loader.RegisterFunction(std::move(info));
 }
 

--- a/src/aggregates/pac_clip_sum.cpp
+++ b/src/aggregates/pac_clip_sum.cpp
@@ -5,17 +5,6 @@
 #include <cmath>
 
 namespace duckdb {
-struct PacIdentityHash {
-	static inline uint64_t Transform(uint64_t key_hash) {
-		return key_hash;
-	}
-};
-
-struct PacDpSampleHash {
-	static inline uint64_t Transform(uint64_t key_hash) {
-		return DpSampleHash(key_hash);
-	}
-};
 
 // ============================================================================
 // Inner state update: add one unsigned value to the state

--- a/src/aggregates/pac_sum.cpp
+++ b/src/aggregates/pac_sum.cpp
@@ -7,6 +7,18 @@
 #include <atomic>
 
 namespace duckdb {
+struct PacIdentityHash {
+	static inline uint64_t Transform(uint64_t key_hash) {
+		return key_hash;
+	}
+};
+
+struct PacDpSampleHash {
+	static inline uint64_t Transform(uint64_t key_hash) {
+		return DpSampleHash(key_hash);
+	}
+};
+
 // ============================================================================
 // State type selection for scatter updates
 // ============================================================================
@@ -231,7 +243,7 @@ inline void PacSumUpdateOne(PacSumIntStateWrapper<SIGNED> &agg, uint64_t key_has
 #endif // PAC_NOBUFFERING
 
 // PacSumUpdate - unified for both int and double states
-template <class State, bool SIGNED, class VALUE_TYPE, class INPUT_TYPE>
+template <class State, bool SIGNED, class VALUE_TYPE, class INPUT_TYPE, class HASH_TRANSFORM = PacIdentityHash>
 static void PacSumUpdate(Vector inputs[], State &state, idx_t count, ArenaAllocator &allocator) {
 	UnifiedVectorFormat hash_data, value_data;
 	inputs[0].ToUnifiedFormat(count, hash_data);
@@ -243,7 +255,8 @@ static void PacSumUpdate(Vector inputs[], State &state, idx_t count, ArenaAlloca
 		for (idx_t i = 0; i < count; i++) {
 			auto h_idx = hash_data.sel->get_index(i);
 			auto v_idx = value_data.sel->get_index(i);
-			PacSumUpdateOne<SIGNED>(state, hashes[h_idx], ConvertValue<VALUE_TYPE>::convert(values[v_idx]), allocator);
+			PacSumUpdateOne<SIGNED>(state, HASH_TRANSFORM::Transform(hashes[h_idx]),
+			                        ConvertValue<VALUE_TYPE>::convert(values[v_idx]), allocator);
 		}
 	} else {
 		for (idx_t i = 0; i < count; i++) {
@@ -252,12 +265,13 @@ static void PacSumUpdate(Vector inputs[], State &state, idx_t count, ArenaAlloca
 			if (!hash_data.validity.RowIsValid(h_idx) || !value_data.validity.RowIsValid(v_idx)) {
 				continue;
 			}
-			PacSumUpdateOne<SIGNED>(state, hashes[h_idx], ConvertValue<VALUE_TYPE>::convert(values[v_idx]), allocator);
+			PacSumUpdateOne<SIGNED>(state, HASH_TRANSFORM::Transform(hashes[h_idx]),
+			                        ConvertValue<VALUE_TYPE>::convert(values[v_idx]), allocator);
 		}
 	}
 }
 
-template <class State, bool SIGNED, class VALUE_TYPE, class INPUT_TYPE>
+template <class State, bool SIGNED, class VALUE_TYPE, class INPUT_TYPE, class HASH_TRANSFORM = PacIdentityHash>
 static void PacSumScatterUpdate(Vector inputs[], Vector &states, idx_t count, ArenaAllocator &allocator) {
 	UnifiedVectorFormat hash_data, value_data, sdata;
 	inputs[0].ToUnifiedFormat(count, hash_data);
@@ -275,7 +289,8 @@ static void PacSumScatterUpdate(Vector inputs[], Vector &states, idx_t count, Ar
 		if (!hash_data.validity.RowIsValid(h_idx) || !value_data.validity.RowIsValid(v_idx)) {
 			continue; // ignore NULLs
 		}
-		PacSumUpdateOne<SIGNED>(*state, hashes[h_idx], ConvertValue<VALUE_TYPE>::convert(values[v_idx]), allocator);
+		PacSumUpdateOne<SIGNED>(*state, HASH_TRANSFORM::Transform(hashes[h_idx]),
+		                        ConvertValue<VALUE_TYPE>::convert(values[v_idx]), allocator);
 	}
 }
 
@@ -539,6 +554,19 @@ void PacSumScatterUpdateDouble(Vector inputs[], AggregateInputData &aggr_input_d
 	PacSumScatterUpdate<ScatterDoubleState, true, double, double>(inputs, states, count, aggr_input_data.allocator);
 }
 
+static void DpSampleSumUpdateDouble(Vector inputs[], AggregateInputData &aggr_input_data, idx_t, data_ptr_t state_p,
+                                    idx_t count) {
+	auto &state = *reinterpret_cast<ScatterDoubleState *>(state_p);
+	PacSumUpdate<ScatterDoubleState, true, double, double, PacDpSampleHash>(inputs, state, count,
+	                                                                        aggr_input_data.allocator);
+}
+
+static void DpSampleSumScatterUpdateDouble(Vector inputs[], AggregateInputData &aggr_input_data, idx_t, Vector &states,
+                                           idx_t count) {
+	PacSumScatterUpdate<ScatterDoubleState, true, double, double, PacDpSampleHash>(inputs, states, count,
+	                                                                               aggr_input_data.allocator);
+}
+
 // instantiate Combine methods
 void PacSumCombineSigned(Vector &src, Vector &dst, AggregateInputData &aggr, idx_t count) {
 	PacSumCombineInt<true>(src, dst, count, aggr.allocator);
@@ -574,6 +602,11 @@ static unique_ptr<FunctionData> PacBindWithScaleDivisor(ClientContext &ctx, vect
 unique_ptr<FunctionData> // Bind function for pac_sum with optional mi parameter (must be constant)
 PacSumBind(ClientContext &ctx, AggregateFunction &, vector<unique_ptr<Expression>> &args) {
 	return PacBindWithScaleDivisor(ctx, args, 1.0); // scale_divisor=1.0 for sum
+}
+
+static unique_ptr<FunctionData> DpSampleSumBind(ClientContext &ctx, AggregateFunction &,
+                                                vector<unique_ptr<Expression>> &) {
+	return make_uniq<PacBindData>(ctx, 0.0, 1.0, 1.0, false);
 }
 
 idx_t PacSumIntStateSize(const AggregateFunction &) {
@@ -729,11 +762,14 @@ void RegisterPacSumFunctions(ExtensionLoader &loader) {
 // it returns all 64 counters so the outer query can evaluate the comparison
 // against all subsamples and produce a mask.
 
+enum class PacSumCountersFinalizeMode : uint8_t { PAC, DP_SAMPLE };
+
 // FinalizeCounters for pac_sum_counters.
 // Returns LIST<DOUBLE> with exactly 64 elements (no NULLs).
 // Position j is 0 if key_hash bit j is 0, otherwise value * 2 (to compensate for 50% sampling).
-template <class State, bool SIGNED>
-void PacSumAvgFinalizeCounters(Vector &states, AggregateInputData &input, Vector &result, idx_t count, idx_t offset) {
+template <class State, bool SIGNED, PacSumCountersFinalizeMode MODE>
+static void PacSumAvgFinalizeCountersInternal(Vector &states, AggregateInputData &input, Vector &result, idx_t count,
+                                              idx_t offset) {
 	auto state_ptrs = FlatVector::GetData<State *>(states);
 
 	// Result is LIST<DOUBLE>
@@ -749,6 +785,7 @@ void PacSumAvgFinalizeCounters(Vector &states, AggregateInputData &input, Vector
 
 	// correction factor for value scaling
 	double correction = input.bind_data ? input.bind_data->Cast<PacBindData>().correction : 1.0;
+	bool dp_sample = MODE == PacSumCountersFinalizeMode::DP_SAMPLE;
 
 	for (idx_t i = 0; i < count; i++) {
 #ifndef PAC_NOBUFFERING
@@ -782,19 +819,29 @@ void PacSumAvgFinalizeCounters(Vector &states, AggregateInputData &input, Vector
 #endif
 		}
 
-		CheckPacSampleDiversity(key_hash, buf, update_count, "pac_noised_sum", input.bind_data->Cast<PacBindData>());
+		if (!dp_sample) {
+			CheckPacSampleDiversity(key_hash, buf, update_count, "pac_noised_sum",
+			                        input.bind_data->Cast<PacBindData>());
+		}
 
-		// Copy counters to list: 0 where key_hash bit is 0, value * 2 otherwise
-		// pac_sum_counters needs 2x compensation to account for ~50% of values in each counter
+		// PAC counters need 2x compensation for 50% sampling; DP sample counters use their own lane probability.
 		idx_t base = i * 64;
 		for (int j = 0; j < 64; j++) {
-			if ((key_hash >> j) & 1ULL) {
+			if (dp_sample) {
+				child_data[base + j] = static_cast<PAC_FLOAT>(buf[j] * DP_SAMPLE_RESCALE);
+			} else if ((key_hash >> j) & 1ULL) {
 				child_data[base + j] = static_cast<PAC_FLOAT>(buf[j] * 2.0 * correction);
 			} else {
 				child_data[base + j] = 0.0; // 0 for positions not sampled
 			}
 		}
 	}
+}
+
+template <class State, bool SIGNED>
+void PacSumAvgFinalizeCounters(Vector &states, AggregateInputData &input, Vector &result, idx_t count, idx_t offset) {
+	PacSumAvgFinalizeCountersInternal<State, SIGNED, PacSumCountersFinalizeMode::PAC>(states, input, result, count,
+	                                                                                  offset);
 }
 
 // Instantiate counter finalize methods for pac_sum_counters
@@ -809,6 +856,11 @@ static void PacSumFinalizeCountersUnsigned(Vector &states, AggregateInputData &i
 static void PacSumFinalizeCountersDouble(Vector &states, AggregateInputData &input, Vector &result, idx_t count,
                                          idx_t offset) {
 	PacSumAvgFinalizeCounters<ScatterDoubleState, true>(states, input, result, count, offset);
+}
+static void DpSampleSumFinalizeCountersDouble(Vector &states, AggregateInputData &input, Vector &result, idx_t count,
+                                              idx_t offset) {
+	PacSumAvgFinalizeCountersInternal<ScatterDoubleState, true, PacSumCountersFinalizeMode::DP_SAMPLE>(
+	    states, input, result, count, offset);
 }
 
 // Helper to register both 2-param and 3-param versions for pac_sum_counters
@@ -884,6 +936,21 @@ void RegisterPacSumCountersFunctions(ExtensionLoader &loader) {
 	counters_desc.description = "[INTERNAL] Returns 64 PAC subsample counters as LIST for categorical queries.";
 	counters_info.descriptions.push_back(std::move(counters_desc));
 	loader.RegisterFunction(std::move(counters_info));
+}
+
+void RegisterDpSampleSumFunctions(ExtensionLoader &loader) {
+	auto list_type = LogicalType::LIST(PacFloatLogicalType());
+	AggregateFunctionSet set("dp_sample_sum");
+	set.AddFunction(AggregateFunction("dp_sample_sum", {LogicalType::UBIGINT, LogicalType::DOUBLE}, list_type,
+	                                  PacSumDoubleStateSize, PacSumDoubleInitialize, DpSampleSumScatterUpdateDouble,
+	                                  PacSumCombineDoubleWrapper, DpSampleSumFinalizeCountersDouble,
+	                                  FunctionNullHandling::DEFAULT_NULL_HANDLING, DpSampleSumUpdateDouble,
+	                                  DpSampleSumBind));
+	CreateAggregateFunctionInfo info(set);
+	FunctionDescription desc;
+	desc.description = "[INTERNAL] Returns 64 sample-median DP counters for SUM-like values.";
+	info.descriptions.push_back(std::move(desc));
+	loader.RegisterFunction(std::move(info));
 }
 
 } // namespace duckdb

--- a/src/aggregates/pac_sum.cpp
+++ b/src/aggregates/pac_sum.cpp
@@ -7,18 +7,6 @@
 #include <atomic>
 
 namespace duckdb {
-struct PacIdentityHash {
-	static inline uint64_t Transform(uint64_t key_hash) {
-		return key_hash;
-	}
-};
-
-struct PacDpSampleHash {
-	static inline uint64_t Transform(uint64_t key_hash) {
-		return DpSampleHash(key_hash);
-	}
-};
-
 // ============================================================================
 // State type selection for scatter updates
 // ============================================================================

--- a/src/compiler/dp_elastic_compiler.cpp
+++ b/src/compiler/dp_elastic_compiler.cpp
@@ -776,7 +776,6 @@ static LogicalProjection *WrapSampleMedianProjection(OptimizerExtensionInput &in
 		    make_uniq<BoundColumnRefExpression>(agg->types[n_groups + ai], ColumnBinding(agg->aggregate_index, ai)));
 		children.push_back(make_uniq<BoundConstantExpression>(Value::DOUBLE(epsilon / k)));
 		children.push_back(make_uniq<BoundConstantExpression>(Value::DOUBLE(delta)));
-		children.push_back(make_uniq<BoundConstantExpression>(Value::INTEGER(DP_SAMPLE_DRAWS)));
 		children.push_back(make_uniq<BoundConstantExpression>(Value::DOUBLE(lowers[ai])));
 		children.push_back(make_uniq<BoundConstantExpression>(Value::DOUBLE(uppers[ai])));
 		unique_ptr<Expression> noised = BindScalarLocal(input, "dp_smooth_median_noise", std::move(children));

--- a/src/compiler/dp_elastic_compiler.cpp
+++ b/src/compiler/dp_elastic_compiler.cpp
@@ -811,13 +811,8 @@ static LogicalProjection *WrapSampleMedianProjection(OptimizerExtensionInput &in
 	return proj_ptr;
 }
 
-static void RewriteAggregateToSampleMedian(OptimizerExtensionInput &input, unique_ptr<LogicalOperator> &plan,
-                                           LogicalAggregate *agg, unique_ptr<Expression> pu_hash_expr) {
-	auto &binder = input.optimizer.binder;
-	idx_t lower_group_index = binder.GenerateTableIndex();
-	idx_t lower_agg_index = binder.GenerateTableIndex();
-	idx_t num_original_groups = agg->groups.size();
-
+static void RewriteAggregateToSampleMedian(OptimizerExtensionInput &input, LogicalAggregate *agg,
+                                           unique_ptr<Expression> pu_hash_expr) {
 	vector<unique_ptr<Expression>> lower_expressions;
 	lower_expressions.reserve(agg->expressions.size());
 	for (auto &expr : agg->expressions) {
@@ -839,30 +834,17 @@ static void RewriteAggregateToSampleMedian(OptimizerExtensionInput &input, uniqu
 		lower_expressions.back()->Cast<BoundAggregateExpression>().filter = aggr.filter ? aggr.filter->Copy() : nullptr;
 	}
 
-	auto lower_agg = make_uniq<LogicalAggregate>(lower_group_index, lower_agg_index, std::move(lower_expressions));
-	for (auto &g : agg->groups) {
-		lower_agg->groups.push_back(g->Copy());
-	}
-	lower_agg->groups.push_back(pu_hash_expr->Copy());
-	lower_agg->children.push_back(std::move(agg->children[0]));
-	lower_agg->ResolveOperatorTypes();
-
-	for (idx_t gi = 0; gi < num_original_groups; gi++) {
-		agg->groups[gi] =
-		    make_uniq<BoundColumnRefExpression>(lower_agg->types[gi], ColumnBinding(lower_group_index, gi));
-	}
-	auto pu_hash_ref = make_uniq<BoundColumnRefExpression>(LogicalType::UBIGINT,
-	                                                       ColumnBinding(lower_group_index, num_original_groups));
+	auto pre_agg = InsertPuPreAggregation(input, agg, std::move(lower_expressions), std::move(pu_hash_expr));
 
 	for (idx_t ai = 0; ai < agg->expressions.size(); ai++) {
 		auto &original = agg->expressions[ai]->Cast<BoundAggregateExpression>();
-		auto lower_type = lower_agg->types[num_original_groups + 1 + ai];
+		auto lower_type = pre_agg.lower_agg->types[pre_agg.num_original_groups + 1 + ai];
 		unique_ptr<Expression> lower_ref =
-		    make_uniq<BoundColumnRefExpression>(lower_type, ColumnBinding(lower_agg_index, ai));
+		    make_uniq<BoundColumnRefExpression>(lower_type, ColumnBinding(pre_agg.lower_agg_index, ai));
 		lower_ref = BoundCastExpression::AddCastToType(input.context, std::move(lower_ref), LogicalType::DOUBLE);
 
 		vector<unique_ptr<Expression>> children;
-		children.push_back(pu_hash_ref->Copy());
+		children.push_back(pre_agg.pu_hash_ref->Copy());
 		children.push_back(std::move(lower_ref));
 		if (original.function.name == "sum") {
 			agg->expressions[ai] = BindAggregateLocal(input, "dp_sample_clip_sum", std::move(children));
@@ -870,7 +852,6 @@ static void RewriteAggregateToSampleMedian(OptimizerExtensionInput &input, uniqu
 			agg->expressions[ai] = BindAggregateLocal(input, "dp_sample_sum", std::move(children));
 		}
 	}
-	agg->children[0] = std::move(lower_agg);
 	agg->ResolveOperatorTypes();
 }
 
@@ -1050,7 +1031,7 @@ void CompileDPSampleMedianQuery(const PrivacyCompatibilityResult &check, Optimiz
 	}
 
 	auto pu_hash_expr = BuildSamplePuHashExpression(input, plan, eligibility.fk_chain, check);
-	RewriteAggregateToSampleMedian(input, plan, agg, std::move(pu_hash_expr));
+	RewriteAggregateToSampleMedian(input, agg, std::move(pu_hash_expr));
 
 	LogicalOperator *projection_anchor = agg;
 	Value threshold_val;

--- a/src/compiler/dp_elastic_compiler.cpp
+++ b/src/compiler/dp_elastic_compiler.cpp
@@ -446,41 +446,6 @@ static double Sensitivity(const BoundAggregateExpression &aggr, double sum_bound
 	throw InternalException("dp_elastic: Sensitivity received unsupported '" + name + "'");
 }
 
-static string QuoteIdentifierDP(const string &identifier) {
-	string result = "\"";
-	for (auto c : identifier) {
-		if (c == '"') {
-			result += "\"\"";
-		} else {
-			result += c;
-		}
-	}
-	result += "\"";
-	return result;
-}
-
-static double ComputeTableCardinality(ClientContext &context, const string &table_name) {
-	auto &db = DatabaseInstance::GetDatabase(context);
-	Connection conn(db);
-	auto disable_rewrite = conn.Query("SET pac_rewrite=false");
-	if (!disable_rewrite || disable_rewrite->HasError()) {
-		throw InvalidInputException("dp_sample_median: failed to disable privacy rewrite while computing bounds" +
-		                            (disable_rewrite ? (": " + disable_rewrite->GetError()) : ""));
-	}
-	string query = "SELECT COUNT(*) FROM " + QuoteIdentifierDP(table_name);
-	auto result = conn.Query(query);
-	if (!result || result->HasError()) {
-		throw InvalidInputException("dp_sample_median: failed to compute table cardinality for '" + table_name + "'" +
-		                            (result ? (": " + result->GetError()) : ""));
-	}
-	auto chunk = result->Fetch();
-	if (!chunk || chunk->size() == 0) {
-		return 0.0;
-	}
-	auto value = chunk->GetValue(0, 0);
-	return value.IsNull() ? 0.0 : value.DefaultCastAs(LogicalType::DOUBLE).GetValue<double>();
-}
-
 static LogicalGet *FindGetForTable(unique_ptr<LogicalOperator> &plan, const string &table_name) {
 	vector<LogicalGet *> gets;
 	CollectGetNodes(plan.get(), gets);
@@ -757,7 +722,6 @@ WrapAvgRatioProjection(OptimizerExtensionInput &input, unique_ptr<LogicalOperato
 
 static LogicalProjection *WrapSampleMedianProjection(OptimizerExtensionInput &input, unique_ptr<LogicalOperator> &plan,
                                                      LogicalAggregate *agg, double epsilon, double delta,
-                                                     const vector<double> &lowers, const vector<double> &uppers,
                                                      const vector<LogicalType> &output_types,
                                                      LogicalOperator *insert_above) {
 	idx_t n_groups = agg->groups.size();
@@ -776,8 +740,6 @@ static LogicalProjection *WrapSampleMedianProjection(OptimizerExtensionInput &in
 		    make_uniq<BoundColumnRefExpression>(agg->types[n_groups + ai], ColumnBinding(agg->aggregate_index, ai)));
 		children.push_back(make_uniq<BoundConstantExpression>(Value::DOUBLE(epsilon / k)));
 		children.push_back(make_uniq<BoundConstantExpression>(Value::DOUBLE(delta)));
-		children.push_back(make_uniq<BoundConstantExpression>(Value::DOUBLE(lowers[ai])));
-		children.push_back(make_uniq<BoundConstantExpression>(Value::DOUBLE(uppers[ai])));
 		unique_ptr<Expression> noised = BindScalarLocal(input, "dp_smooth_median_noise", std::move(children));
 		if (output_types[ai] != LogicalType::DOUBLE) {
 			noised = BoundCastExpression::AddCastToType(input.context, std::move(noised), output_types[ai]);
@@ -1011,22 +973,10 @@ void CompileDPSampleMedianQuery(const PrivacyCompatibilityResult &check, Optimiz
 	}
 
 	vector<LogicalType> output_types;
-	vector<double> lowers;
-	vector<double> uppers;
-	double row_bound = std::max(1.0, ComputeTableCardinality(input.context, eligibility.fk_chain.tables[0]));
 	output_types.reserve(agg->expressions.size());
-	lowers.reserve(agg->expressions.size());
-	uppers.reserve(agg->expressions.size());
 	for (auto &expr : agg->expressions) {
 		auto &aggr = expr->Cast<BoundAggregateExpression>();
 		output_types.push_back(aggr.return_type);
-		if (aggr.function.name == "sum") {
-			lowers.push_back(-row_bound * sum_bound);
-			uppers.push_back(row_bound * sum_bound);
-		} else {
-			lowers.push_back(0.0);
-			uppers.push_back(row_bound);
-		}
 	}
 
 	auto pu_hash_expr = BuildSamplePuHashExpression(input, plan, eligibility.fk_chain, check);
@@ -1045,7 +995,7 @@ void CompileDPSampleMedianQuery(const PrivacyCompatibilityResult &check, Optimiz
 		projection_anchor = ApplySupportFilter(input, plan, agg, support_pos, support_threshold);
 	}
 
-	WrapSampleMedianProjection(input, plan, agg, epsilon, delta, lowers, uppers, output_types, projection_anchor);
+	WrapSampleMedianProjection(input, plan, agg, epsilon, delta, output_types, projection_anchor);
 
 #if PRIVACY_DEBUG
 	PRIVACY_DEBUG_PRINT("=== PLAN AFTER DP_SAMPLE_MEDIAN TRANSFORMATION ===");

--- a/src/compiler/dp_elastic_compiler.cpp
+++ b/src/compiler/dp_elastic_compiler.cpp
@@ -1,4 +1,5 @@
 #include "compiler/dp_elastic_compiler.hpp"
+#include "aggregates/pac_aggregate.hpp"
 #include "utils/privacy_helpers.hpp"
 #include "query_processing/pac_plan_traversal.hpp"
 #include "query_processing/pac_expression_builder.hpp"
@@ -57,15 +58,13 @@ struct AvgInfo {
 
 // Bind a plain aggregate function (sum, count_star, etc.) by name.
 static unique_ptr<Expression> BindAggregateLocal(OptimizerExtensionInput &input, const string &func_name,
-                                                 unique_ptr<Expression> arg,
+                                                 vector<unique_ptr<Expression>> children,
                                                  AggregateType aggr_type = AggregateType::NON_DISTINCT) {
 	FunctionBinder function_binder(input.context);
 	ErrorData error;
-	vector<unique_ptr<Expression>> children;
 	vector<LogicalType> arg_types;
-	if (arg) {
-		arg_types.push_back(arg->return_type);
-		children.push_back(std::move(arg));
+	for (auto &child : children) {
+		arg_types.push_back(child->return_type);
 	}
 	auto &entry = Catalog::GetSystemCatalog(input.context)
 	                  .GetEntry<AggregateFunctionCatalogEntry>(input.context, DEFAULT_SCHEMA, func_name);
@@ -75,6 +74,27 @@ static unique_ptr<Expression> BindAggregateLocal(OptimizerExtensionInput &input,
 	}
 	auto func = entry.functions.GetFunctionByOffset(best.GetIndex());
 	return function_binder.BindAggregateFunction(func, std::move(children), nullptr, aggr_type);
+}
+
+static unique_ptr<Expression> BindAggregateLocal(OptimizerExtensionInput &input, const string &func_name,
+                                                 unique_ptr<Expression> arg,
+                                                 AggregateType aggr_type = AggregateType::NON_DISTINCT) {
+	vector<unique_ptr<Expression>> children;
+	if (arg) {
+		children.push_back(std::move(arg));
+	}
+	return BindAggregateLocal(input, func_name, std::move(children), aggr_type);
+}
+
+static unique_ptr<Expression> BindScalarLocal(OptimizerExtensionInput &input, const string &func_name,
+                                              vector<unique_ptr<Expression>> children) {
+	FunctionBinder function_binder(input.context);
+	ErrorData error;
+	auto expr = function_binder.BindScalarFunction(DEFAULT_SCHEMA, func_name, std::move(children), error);
+	if (error.HasError()) {
+		throw InternalException("dp_elastic: failed to bind scalar function '" + func_name + "': " + error.Message());
+	}
+	return expr;
 }
 
 // Replace each AVG(x) with SUM(x) in-place and append a COUNT(*) at the end.
@@ -426,6 +446,41 @@ static double Sensitivity(const BoundAggregateExpression &aggr, double sum_bound
 	throw InternalException("dp_elastic: Sensitivity received unsupported '" + name + "'");
 }
 
+static string QuoteIdentifierDP(const string &identifier) {
+	string result = "\"";
+	for (auto c : identifier) {
+		if (c == '"') {
+			result += "\"\"";
+		} else {
+			result += c;
+		}
+	}
+	result += "\"";
+	return result;
+}
+
+static double ComputeTableCardinality(ClientContext &context, const string &table_name) {
+	auto &db = DatabaseInstance::GetDatabase(context);
+	Connection conn(db);
+	auto disable_rewrite = conn.Query("SET pac_rewrite=false");
+	if (!disable_rewrite || disable_rewrite->HasError()) {
+		throw InvalidInputException("dp_sample_median: failed to disable privacy rewrite while computing bounds" +
+		                            (disable_rewrite ? (": " + disable_rewrite->GetError()) : ""));
+	}
+	string query = "SELECT COUNT(*) FROM " + QuoteIdentifierDP(table_name);
+	auto result = conn.Query(query);
+	if (!result || result->HasError()) {
+		throw InvalidInputException("dp_sample_median: failed to compute table cardinality for '" + table_name + "'" +
+		                            (result ? (": " + result->GetError()) : ""));
+	}
+	auto chunk = result->Fetch();
+	if (!chunk || chunk->size() == 0) {
+		return 0.0;
+	}
+	auto value = chunk->GetValue(0, 0);
+	return value.IsNull() ? 0.0 : value.DefaultCastAs(LogicalType::DOUBLE).GetValue<double>();
+}
+
 static LogicalGet *FindGetForTable(unique_ptr<LogicalOperator> &plan, const string &table_name) {
 	vector<LogicalGet *> gets;
 	CollectGetNodes(plan.get(), gets);
@@ -458,6 +513,40 @@ static unique_ptr<Expression> BuildSupportKeyExpression(unique_ptr<LogicalOperat
 	auto col_index = get->GetColumnIds()[proj_idx];
 	auto col_type = get->GetColumnType(col_index);
 	return make_uniq<BoundColumnRefExpression>(col_type, ColumnBinding(get->table_index, proj_idx));
+}
+
+static unique_ptr<Expression> BuildSamplePuHashExpression(OptimizerExtensionInput &input,
+                                                          unique_ptr<LogicalOperator> &plan, const DPFKChain &chain,
+                                                          const PrivacyCompatibilityResult &check) {
+	if (chain.tables.size() > 2) {
+		throw InvalidInputException("dp_sample_median: only single-table PU queries and one-hop PRIVACY_LINK chains "
+		                            "are currently supported");
+	}
+	string source_table = chain.tables[0];
+	auto *get = FindGetForTable(plan, source_table);
+	if (!get) {
+		throw InternalException("dp_sample_median: could not find source table '" + source_table + "'");
+	}
+
+	vector<string> key_columns;
+	if (chain.tables.size() == 1) {
+		auto meta_it = check.table_metadata.find(source_table);
+		if (meta_it != check.table_metadata.end()) {
+			key_columns = meta_it->second.pks;
+		}
+		if (key_columns.empty()) {
+			key_columns = FindPacKey(input.context, source_table);
+		}
+		if (key_columns.empty()) {
+			throw InvalidInputException("dp_sample_median: privacy unit table '" + source_table +
+			                            "' has no PRIVACY_KEY columns");
+		}
+	} else {
+		key_columns.push_back(chain.fk_cols[0]);
+	}
+
+	auto binding = InsertHashProjectionAboveGet(input, plan, *get, key_columns, false);
+	return make_uniq<BoundColumnRefExpression>(LogicalType::UBIGINT, binding);
 }
 
 static optional_idx AddSupportAggregate(OptimizerExtensionInput &input, unique_ptr<LogicalOperator> &plan,
@@ -666,6 +755,125 @@ WrapAvgRatioProjection(OptimizerExtensionInput &input, unique_ptr<LogicalOperato
 	return {ratio_idx, ratio_ptr};
 }
 
+static LogicalProjection *WrapSampleMedianProjection(OptimizerExtensionInput &input, unique_ptr<LogicalOperator> &plan,
+                                                     LogicalAggregate *agg, double epsilon, double delta,
+                                                     const vector<double> &lowers, const vector<double> &uppers,
+                                                     const vector<LogicalType> &output_types,
+                                                     LogicalOperator *insert_above) {
+	idx_t n_groups = agg->groups.size();
+	idx_t n_aggs = output_types.size();
+	double k = static_cast<double>(n_aggs);
+
+	vector<unique_ptr<Expression>> proj_exprs;
+	proj_exprs.reserve(n_groups + n_aggs);
+	for (idx_t gi = 0; gi < n_groups; gi++) {
+		proj_exprs.push_back(make_uniq<BoundColumnRefExpression>(agg->types[gi], ColumnBinding(agg->group_index, gi)));
+	}
+
+	for (idx_t ai = 0; ai < n_aggs; ai++) {
+		vector<unique_ptr<Expression>> children;
+		children.push_back(
+		    make_uniq<BoundColumnRefExpression>(agg->types[n_groups + ai], ColumnBinding(agg->aggregate_index, ai)));
+		children.push_back(make_uniq<BoundConstantExpression>(Value::DOUBLE(epsilon / k)));
+		children.push_back(make_uniq<BoundConstantExpression>(Value::DOUBLE(delta)));
+		children.push_back(make_uniq<BoundConstantExpression>(Value::INTEGER(DP_SAMPLE_DRAWS)));
+		children.push_back(make_uniq<BoundConstantExpression>(Value::DOUBLE(lowers[ai])));
+		children.push_back(make_uniq<BoundConstantExpression>(Value::DOUBLE(uppers[ai])));
+		unique_ptr<Expression> noised = BindScalarLocal(input, "dp_smooth_median_noise", std::move(children));
+		if (output_types[ai] != LogicalType::DOUBLE) {
+			noised = BoundCastExpression::AddCastToType(input.context, std::move(noised), output_types[ai]);
+		}
+		proj_exprs.push_back(std::move(noised));
+	}
+
+	idx_t proj_idx = input.optimizer.binder.GenerateTableIndex();
+	auto projection = make_uniq<LogicalProjection>(proj_idx, std::move(proj_exprs));
+	auto *slot = FindSlotForOperator(plan, insert_above);
+	if (!slot) {
+		throw InternalException("dp_sample_median: could not locate aggregate slot for median projection");
+	}
+	auto old_node = std::move(*slot);
+	projection->children.push_back(std::move(old_node));
+	projection->ResolveOperatorTypes();
+	auto *proj_ptr = projection.get();
+	*slot = std::move(projection);
+
+	ColumnBindingReplacer replacer;
+	for (idx_t gi = 0; gi < n_groups; gi++) {
+		replacer.replacement_bindings.emplace_back(ColumnBinding(agg->group_index, gi), ColumnBinding(proj_idx, gi));
+	}
+	for (idx_t ai = 0; ai < n_aggs; ai++) {
+		replacer.replacement_bindings.emplace_back(ColumnBinding(agg->aggregate_index, ai),
+		                                           ColumnBinding(proj_idx, n_groups + ai));
+	}
+	replacer.stop_operator = proj_ptr;
+	replacer.VisitOperator(*plan);
+	return proj_ptr;
+}
+
+static void RewriteAggregateToSampleMedian(OptimizerExtensionInput &input, unique_ptr<LogicalOperator> &plan,
+                                           LogicalAggregate *agg, unique_ptr<Expression> pu_hash_expr) {
+	auto &binder = input.optimizer.binder;
+	idx_t lower_group_index = binder.GenerateTableIndex();
+	idx_t lower_agg_index = binder.GenerateTableIndex();
+	idx_t num_original_groups = agg->groups.size();
+
+	vector<unique_ptr<Expression>> lower_expressions;
+	lower_expressions.reserve(agg->expressions.size());
+	for (auto &expr : agg->expressions) {
+		auto &aggr = expr->Cast<BoundAggregateExpression>();
+		vector<unique_ptr<Expression>> children;
+		if (aggr.function.name == "count_star") {
+			lower_expressions.push_back(BindAggregateLocal(input, "count_star", std::move(children)));
+		} else if (aggr.function.name == "count") {
+			if (!aggr.children.empty()) {
+				children.push_back(aggr.children[0]->Copy());
+			}
+			lower_expressions.push_back(BindAggregateLocal(input, "count", std::move(children)));
+		} else if (aggr.function.name == "sum") {
+			children.push_back(aggr.children[0]->Copy());
+			lower_expressions.push_back(BindAggregateLocal(input, "sum", std::move(children)));
+		} else {
+			throw InvalidInputException("dp_sample_median: only COUNT and SUM aggregates are supported");
+		}
+		lower_expressions.back()->Cast<BoundAggregateExpression>().filter = aggr.filter ? aggr.filter->Copy() : nullptr;
+	}
+
+	auto lower_agg = make_uniq<LogicalAggregate>(lower_group_index, lower_agg_index, std::move(lower_expressions));
+	for (auto &g : agg->groups) {
+		lower_agg->groups.push_back(g->Copy());
+	}
+	lower_agg->groups.push_back(pu_hash_expr->Copy());
+	lower_agg->children.push_back(std::move(agg->children[0]));
+	lower_agg->ResolveOperatorTypes();
+
+	for (idx_t gi = 0; gi < num_original_groups; gi++) {
+		agg->groups[gi] =
+		    make_uniq<BoundColumnRefExpression>(lower_agg->types[gi], ColumnBinding(lower_group_index, gi));
+	}
+	auto pu_hash_ref = make_uniq<BoundColumnRefExpression>(LogicalType::UBIGINT,
+	                                                       ColumnBinding(lower_group_index, num_original_groups));
+
+	for (idx_t ai = 0; ai < agg->expressions.size(); ai++) {
+		auto &original = agg->expressions[ai]->Cast<BoundAggregateExpression>();
+		auto lower_type = lower_agg->types[num_original_groups + 1 + ai];
+		unique_ptr<Expression> lower_ref =
+		    make_uniq<BoundColumnRefExpression>(lower_type, ColumnBinding(lower_agg_index, ai));
+		lower_ref = BoundCastExpression::AddCastToType(input.context, std::move(lower_ref), LogicalType::DOUBLE);
+
+		vector<unique_ptr<Expression>> children;
+		children.push_back(pu_hash_ref->Copy());
+		children.push_back(std::move(lower_ref));
+		if (original.function.name == "sum") {
+			agg->expressions[ai] = BindAggregateLocal(input, "dp_sample_clip_sum", std::move(children));
+		} else {
+			agg->expressions[ai] = BindAggregateLocal(input, "dp_sample_sum", std::move(children));
+		}
+	}
+	agg->children[0] = std::move(lower_agg);
+	agg->ResolveOperatorTypes();
+}
+
 // ----------------------------------------------------------------------------
 // Entry point
 // ----------------------------------------------------------------------------
@@ -767,6 +975,100 @@ void CompileDPElasticQuery(const PrivacyCompatibilityResult &check, OptimizerExt
 
 #if PRIVACY_DEBUG
 	PRIVACY_DEBUG_PRINT("=== PLAN AFTER DP_ELASTIC TRANSFORMATION ===");
+	plan->Print();
+#endif
+}
+
+void CompileDPSampleMedianQuery(const PrivacyCompatibilityResult &check, OptimizerExtensionInput &input,
+                                unique_ptr<LogicalOperator> &plan, const vector<string> &privacy_units,
+                                const string &query_hash) {
+	(void)privacy_units;
+	(void)query_hash;
+	PRIVACY_DEBUG_PRINT("[DP_SAMPLE_MEDIAN] CompileDPSampleMedianQuery: start");
+
+	double epsilon = GetDpEpsilon(input.context, 1.0);
+	if (epsilon <= 0.0 || !std::isfinite(epsilon)) {
+		throw InvalidInputException("dp_sample_median: dp_epsilon must be a positive finite number (got " +
+		                            std::to_string(epsilon) + ")");
+	}
+	double delta = 0.0;
+	if (!TryGetDpDelta(input.context, delta)) {
+		throw InvalidInputException(
+		    "dp_sample_median: dp_delta must be set. Use SET dp_delta=<value> or PRAGMA refresh_dp_stats(<epsilon>).");
+	}
+	if (delta <= 0.0 || delta >= 0.5 || !std::isfinite(delta)) {
+		throw InvalidInputException("dp_sample_median: dp_delta must be in (0, 0.5)");
+	}
+
+	plan->ResolveOperatorTypes();
+	auto eligibility = CheckDPEligibility(plan, privacy_units, check);
+	auto *agg = eligibility.top_agg;
+	for (auto &expr : agg->expressions) {
+		auto &aggr = expr->Cast<BoundAggregateExpression>();
+		if (aggr.function.name == "avg") {
+			throw InvalidInputException("dp_sample_median: AVG is not supported");
+		}
+		if (aggr.function.name != "count" && aggr.function.name != "count_star" && aggr.function.name != "sum") {
+			throw InvalidInputException("dp_sample_median: only COUNT and SUM aggregates are supported");
+		}
+	}
+
+	double sum_bound = 0.0;
+	bool has_sum = AggregateContainsSum(agg);
+	if (has_sum) {
+		if (!TryGetDpSumBound(input.context, sum_bound)) {
+			throw InvalidInputException("dp_sample_median: dp_sum_bound must be set for SUM aggregates");
+		}
+		if (sum_bound <= 0.0 || !std::isfinite(sum_bound)) {
+			throw InvalidInputException("dp_sample_median: dp_sum_bound must be a positive finite number");
+		}
+		Value clip_support_val;
+		if (!input.context.TryGetCurrentSetting("pac_clip_support", clip_support_val) || clip_support_val.IsNull() ||
+		    clip_support_val.GetValue<int64_t>() <= 0) {
+			throw InvalidInputException("dp_sample_median: pac_clip_support must be set for SUM aggregates");
+		}
+		ClipSumInputs(input, agg, sum_bound);
+	}
+
+	vector<LogicalType> output_types;
+	vector<double> lowers;
+	vector<double> uppers;
+	double row_bound = std::max(1.0, ComputeTableCardinality(input.context, eligibility.fk_chain.tables[0]));
+	output_types.reserve(agg->expressions.size());
+	lowers.reserve(agg->expressions.size());
+	uppers.reserve(agg->expressions.size());
+	for (auto &expr : agg->expressions) {
+		auto &aggr = expr->Cast<BoundAggregateExpression>();
+		output_types.push_back(aggr.return_type);
+		if (aggr.function.name == "sum") {
+			lowers.push_back(-row_bound * sum_bound);
+			uppers.push_back(row_bound * sum_bound);
+		} else {
+			lowers.push_back(0.0);
+			uppers.push_back(row_bound);
+		}
+	}
+
+	auto pu_hash_expr = BuildSamplePuHashExpression(input, plan, eligibility.fk_chain, check);
+	RewriteAggregateToSampleMedian(input, plan, agg, std::move(pu_hash_expr));
+
+	LogicalOperator *projection_anchor = agg;
+	Value threshold_val;
+	double support_threshold = 0.0;
+	bool apply_support_filter =
+	    input.context.TryGetCurrentSetting("privacy_min_group_count", threshold_val) && !threshold_val.IsNull() &&
+	    (support_threshold = threshold_val.GetValue<double>()) > 0.0 && std::isfinite(support_threshold);
+	if (apply_support_filter) {
+		idx_t support_pos = agg->expressions.size();
+		agg->expressions.push_back(BindAggregateLocal(input, "count_star", nullptr));
+		agg->ResolveOperatorTypes();
+		projection_anchor = ApplySupportFilter(input, plan, agg, support_pos, support_threshold);
+	}
+
+	WrapSampleMedianProjection(input, plan, agg, epsilon, delta, lowers, uppers, output_types, projection_anchor);
+
+#if PRIVACY_DEBUG
+	PRIVACY_DEBUG_PRINT("=== PLAN AFTER DP_SAMPLE_MEDIAN TRANSFORMATION ===");
 	plan->Print();
 #endif
 }

--- a/src/core/privacy_extension.cpp
+++ b/src/core/privacy_extension.cpp
@@ -308,6 +308,9 @@ static void LoadInternal(ExtensionLoader &loader) {
 	db.config.AddExtensionOption("privacy_mode",
 	                             "Privacy mechanism: 'pac' (default) or 'dp_elastic' for elastic-sensitivity DP",
 	                             LogicalType::VARCHAR, Value("pac"));
+	db.config.AddExtensionOption("dp_strategy",
+	                             "DP strategy for privacy_mode='dp_elastic': 'elastic' or 'sample_median'",
+	                             LogicalType::VARCHAR, Value("elastic"));
 	// Differential privacy budget (ε), used only when privacy_mode = 'dp_elastic'
 	db.config.AddExtensionOption("dp_epsilon", "Differential privacy budget (used when privacy_mode = 'dp_elastic')",
 	                             LogicalType::DOUBLE, Value::DOUBLE(1.0));
@@ -408,9 +411,11 @@ static void LoadInternal(ExtensionLoader &loader) {
 	// Register pac_sum aggregate functions
 	RegisterPacSumFunctions(loader);
 	RegisterPacSumCountersFunctions(loader);
+	RegisterDpSampleSumFunctions(loader);
 	RegisterPacClipSumFunctions(loader);
 	RegisterPacNoisedClipSumFunctions(loader);
 	RegisterPacNoisedClipSumCountFunctions(loader);
+	RegisterDpSampleClipSumFunctions(loader);
 	RegisterPacCountFunctions(loader);
 	RegisterPacCountCountersFunctions(loader);
 	RegisterPacClipCountFunctions(loader);
@@ -444,6 +449,7 @@ static void LoadInternal(ExtensionLoader &loader) {
 
 	// Register dp_laplace_noise scalar function (value, scale) -> value + Lap(scale)
 	RegisterDpLaplaceNoiseFunction(loader);
+	RegisterDpSmoothMedianNoiseFunction(loader);
 
 	// Register PAC parser extension
 	ParserExtension::Register(db.config, PrivacyParserExtension());

--- a/src/core/privacy_optimizer.cpp
+++ b/src/core/privacy_optimizer.cpp
@@ -582,7 +582,15 @@ void PACRewriteRule::PACPreOptimizeFunction(OptimizerExtensionInput &input, uniq
 			// set replan flag for duration of compilation
 			ReplanGuard scoped2(pac_info);
 			if (privacy_mode == "dp_elastic") {
-				CompileDPElasticQuery(check, input, target_plan, privacy_units, query_hash);
+				string dp_strategy = GetDPStrategy(input.context);
+				if (dp_strategy == "elastic") {
+					CompileDPElasticQuery(check, input, target_plan, privacy_units, query_hash);
+				} else if (dp_strategy == "sample_median") {
+					CompileDPSampleMedianQuery(check, input, target_plan, privacy_units, query_hash);
+				} else {
+					throw InvalidInputException("dp_elastic: unknown dp_strategy '" + dp_strategy +
+					                            "' (expected 'elastic' or 'sample_median')");
+				}
 			} else {
 				CompilePacBitsliceQuery(check, input, target_plan, privacy_units, normalized, query_hash);
 			}

--- a/src/include/aggregates/dp_laplace_noise.hpp
+++ b/src/include/aggregates/dp_laplace_noise.hpp
@@ -10,7 +10,7 @@ class ExtensionLoader;
 // Returns value + Lap(scale) (location 0, scale = scale). Deterministic when `privacy_seed` is set.
 void RegisterDpLaplaceNoiseFunction(ExtensionLoader &loader);
 
-// Registers `dp_smooth_median_noise(counters, epsilon, delta, affected, lower, upper) -> DOUBLE`.
+// Registers `dp_smooth_median_noise(counters, epsilon, delta, lower, upper) -> DOUBLE`.
 // The counters are already scaled to full-population estimates.
 void RegisterDpSmoothMedianNoiseFunction(ExtensionLoader &loader);
 

--- a/src/include/aggregates/dp_laplace_noise.hpp
+++ b/src/include/aggregates/dp_laplace_noise.hpp
@@ -10,7 +10,7 @@ class ExtensionLoader;
 // Returns value + Lap(scale) (location 0, scale = scale). Deterministic when `privacy_seed` is set.
 void RegisterDpLaplaceNoiseFunction(ExtensionLoader &loader);
 
-// Registers `dp_smooth_median_noise(counters, epsilon, delta, lower, upper) -> DOUBLE`.
+// Registers `dp_smooth_median_noise(counters, epsilon, delta) -> DOUBLE`.
 // The counters are already scaled to full-population estimates.
 void RegisterDpSmoothMedianNoiseFunction(ExtensionLoader &loader);
 

--- a/src/include/aggregates/dp_laplace_noise.hpp
+++ b/src/include/aggregates/dp_laplace_noise.hpp
@@ -10,4 +10,8 @@ class ExtensionLoader;
 // Returns value + Lap(scale) (location 0, scale = scale). Deterministic when `privacy_seed` is set.
 void RegisterDpLaplaceNoiseFunction(ExtensionLoader &loader);
 
+// Registers `dp_smooth_median_noise(counters, epsilon, delta, affected, lower, upper) -> DOUBLE`.
+// The counters are already scaled to full-population estimates.
+void RegisterDpSmoothMedianNoiseFunction(ExtensionLoader &loader);
+
 } // namespace duckdb

--- a/src/include/aggregates/pac_aggregate.hpp
+++ b/src/include/aggregates/pac_aggregate.hpp
@@ -39,9 +39,11 @@ constexpr double DP_SAMPLE_LANE_PROBABILITY = 0.11837573434899539; // 1 - (63/64
 constexpr double DP_SAMPLE_RESCALE = 1.0 / DP_SAMPLE_LANE_PROBABILITY;
 
 static inline uint64_t DpSampleHash(uint64_t key_hash) {
-	return (1ULL << ((key_hash >> 0) & 63)) | (1ULL << ((key_hash >> 6) & 63)) | (1ULL << ((key_hash >> 12) & 63)) |
-	       (1ULL << ((key_hash >> 18) & 63)) | (1ULL << ((key_hash >> 24) & 63)) | (1ULL << ((key_hash >> 30) & 63)) |
-	       (1ULL << ((key_hash >> 36) & 63)) | (1ULL << ((key_hash >> 42) & 63));
+	uint64_t sample_hash = 0;
+	for (int i = 0; i < DP_SAMPLE_DRAWS; i++) {
+		sample_hash |= 1ULL << ((key_hash >> (i * 6)) & 63);
+	}
+	return sample_hash;
 }
 
 struct PacIdentityHash {

--- a/src/include/aggregates/pac_aggregate.hpp
+++ b/src/include/aggregates/pac_aggregate.hpp
@@ -34,6 +34,19 @@
 
 #define PAC_MAGIC_HASH 2983746509182734091ULL
 
+constexpr int DP_SAMPLE_DRAWS = 8;
+constexpr int DP_SAMPLE_MAX_SHIFT = 42;
+constexpr double DP_SAMPLE_LANE_PROBABILITY = 0.11837573434899539; // 1 - (63/64)^8
+constexpr double DP_SAMPLE_RESCALE = 1.0 / DP_SAMPLE_LANE_PROBABILITY;
+
+static inline uint64_t DpSampleHash(uint64_t key_hash) {
+	uint64_t sample_hash = 0;
+	for (int shift = 0; shift <= DP_SAMPLE_MAX_SHIFT; shift += 6) {
+		sample_hash |= 1ULL << ((key_hash >> shift) & 63);
+	}
+	return sample_hash;
+}
+
 // Cross-platform popcount for 64-bit integers
 // MSVC doesn't have __builtin_popcountll, so we need to handle it differently
 #if defined(_MSC_VER)

--- a/src/include/aggregates/pac_aggregate.hpp
+++ b/src/include/aggregates/pac_aggregate.hpp
@@ -35,17 +35,26 @@
 #define PAC_MAGIC_HASH 2983746509182734091ULL
 
 constexpr int DP_SAMPLE_DRAWS = 8;
-constexpr int DP_SAMPLE_MAX_SHIFT = 42;
 constexpr double DP_SAMPLE_LANE_PROBABILITY = 0.11837573434899539; // 1 - (63/64)^8
 constexpr double DP_SAMPLE_RESCALE = 1.0 / DP_SAMPLE_LANE_PROBABILITY;
 
 static inline uint64_t DpSampleHash(uint64_t key_hash) {
-	uint64_t sample_hash = 0;
-	for (int shift = 0; shift <= DP_SAMPLE_MAX_SHIFT; shift += 6) {
-		sample_hash |= 1ULL << ((key_hash >> shift) & 63);
-	}
-	return sample_hash;
+	return (1ULL << ((key_hash >> 0) & 63)) | (1ULL << ((key_hash >> 6) & 63)) | (1ULL << ((key_hash >> 12) & 63)) |
+	       (1ULL << ((key_hash >> 18) & 63)) | (1ULL << ((key_hash >> 24) & 63)) | (1ULL << ((key_hash >> 30) & 63)) |
+	       (1ULL << ((key_hash >> 36) & 63)) | (1ULL << ((key_hash >> 42) & 63));
 }
+
+struct PacIdentityHash {
+	static inline uint64_t Transform(uint64_t key_hash) {
+		return key_hash;
+	}
+};
+
+struct PacDpSampleHash {
+	static inline uint64_t Transform(uint64_t key_hash) {
+		return DpSampleHash(key_hash);
+	}
+};
 
 // Cross-platform popcount for 64-bit integers
 // MSVC doesn't have __builtin_popcountll, so we need to handle it differently

--- a/src/include/aggregates/pac_clip_sum.hpp
+++ b/src/include/aggregates/pac_clip_sum.hpp
@@ -14,6 +14,7 @@ namespace duckdb {
 void RegisterPacClipSumFunctions(ExtensionLoader &loader);
 void RegisterPacNoisedClipSumFunctions(ExtensionLoader &loader);
 void RegisterPacNoisedClipSumCountFunctions(ExtensionLoader &loader);
+void RegisterDpSampleClipSumFunctions(ExtensionLoader &loader);
 
 // ============================================================================
 // Sum-specific constants (shared constants in pac_clip_aggr.hpp)
@@ -187,12 +188,13 @@ struct PacClipSumIntState {
 	// clip_scale: false=omit unsupported prefix/suffix, true=scale to nearest supported
 	// Interior unsupported levels (between first and last supported) always contribute.
 	// ========================================================================
-	void GetTotals(PAC_FLOAT *dst, int clip_support_threshold = 0, bool clip_scale = false) const {
+	void GetTotals(PAC_FLOAT *dst, int clip_support_threshold = 0, bool clip_scale = false,
+	               bool smooth_clip = false) const {
 		memset(dst, 0, 64 * sizeof(PAC_FLOAT));
 
 		// Pass 1: find first and last supported levels
 		int first_supported = -1, last_supported = -1;
-		if (clip_support_threshold > 0) {
+		if (clip_support_threshold > 0 && !smooth_clip) {
 			ClipFindSupportedRange(levels, max_level_used, 17, clip_support_threshold, first_supported, last_supported);
 		}
 
@@ -202,13 +204,19 @@ struct PacClipSumIntState {
 				continue;
 			}
 
-			int eff =
-			    (clip_support_threshold > 0) ? ClipEffectiveLevel(k, first_supported, last_supported, clip_scale) : k;
+			int eff = (clip_support_threshold > 0 && !smooth_clip)
+			              ? ClipEffectiveLevel(k, first_supported, last_supported, clip_scale)
+			              : k;
 			if (eff < 0) {
 				continue;
 			}
 
 			PAC_FLOAT scale = std::exp2(static_cast<PAC_FLOAT>(CLIP_LEVEL_SHIFT * eff));
+			if (clip_support_threshold > 0 && smooth_clip) {
+				int support = ClipEstimateDistinct(levels[k][17]);
+				scale *= std::min<PAC_FLOAT>(
+				    static_cast<PAC_FLOAT>(support) / static_cast<PAC_FLOAT>(clip_support_threshold), 1.0);
+			}
 
 			// Adjust scale by avg shifted value per PU when rescaling outlier levels
 			if (clip_scale && eff != k) {

--- a/src/include/aggregates/pac_sum.hpp
+++ b/src/include/aggregates/pac_sum.hpp
@@ -45,6 +45,7 @@ using int64_t = signed long long;
 namespace duckdb {
 void RegisterPacSumFunctions(ExtensionLoader &loader);
 void RegisterPacSumCountersFunctions(ExtensionLoader &loader);
+void RegisterDpSampleSumFunctions(ExtensionLoader &loader);
 
 // ============================================================================
 // PAC_SUM(hash_key, value)  aggregate function

--- a/src/include/compiler/dp_elastic_compiler.hpp
+++ b/src/include/compiler/dp_elastic_compiler.hpp
@@ -14,6 +14,10 @@ void CompileDPElasticQuery(const PrivacyCompatibilityResult &check, OptimizerExt
                            unique_ptr<LogicalOperator> &plan, const vector<string> &privacy_units,
                            const string &query_hash);
 
+void CompileDPSampleMedianQuery(const PrivacyCompatibilityResult &check, OptimizerExtensionInput &input,
+                                unique_ptr<LogicalOperator> &plan, const vector<string> &privacy_units,
+                                const string &query_hash);
+
 } // namespace duckdb
 
 #endif // DP_ELASTIC_COMPILER_HPP

--- a/src/include/query_processing/pac_expression_builder.hpp
+++ b/src/include/query_processing/pac_expression_builder.hpp
@@ -57,6 +57,20 @@ unique_ptr<Expression> BindPacAggregate(OptimizerExtensionInput &input, const st
                                         unique_ptr<Expression> hash_expr, unique_ptr<Expression> value_expr,
                                         unique_ptr<Expression> correction_expr = nullptr);
 
+struct PuPreAggregationInfo {
+	LogicalAggregate *lower_agg;
+	idx_t num_original_groups;
+	idx_t lower_agg_index;
+	unique_ptr<Expression> pu_hash_ref;
+};
+
+// Insert a lower aggregate grouped by [original groups..., PU hash], move the current aggregate child below it,
+// and rewrite the top aggregate's groups to reference the lower group output. The caller owns aggregate-specific
+// lower expressions and must rewrite the top aggregate expressions after this helper returns.
+PuPreAggregationInfo InsertPuPreAggregation(OptimizerExtensionInput &input, LogicalAggregate *agg,
+                                            vector<unique_ptr<Expression>> lower_expressions,
+                                            unique_ptr<Expression> pu_hash_expr);
+
 // Bind bit_or(hash_expr) with an IS NOT NULL filter on filter_col_expr.
 // Returns the bound aggregate expression.
 unique_ptr<Expression> BindBitOrAggregate(OptimizerExtensionInput &input, unique_ptr<Expression> hash_expr,

--- a/src/include/utils/privacy_helpers.hpp
+++ b/src/include/utils/privacy_helpers.hpp
@@ -82,6 +82,8 @@ string GetPacCompileMethod(ClientContext &context, const string &default_method 
 
 // Return the selected privacy mechanism: "pac" (default) or "dp_elastic". Lowercased, trimmed.
 string GetPrivacyMode(ClientContext &context);
+// Return the selected DP strategy: "elastic" (default) or "sample_median". Lowercased, trimmed.
+string GetDPStrategy(ClientContext &context);
 // Return the DP budget (ε) from `dp_epsilon`; falls back to default if unset.
 double GetDpEpsilon(ClientContext &context, double default_value = 1.0);
 // Read `dp_sum_bound` into `out`. Returns false if the setting is unset/NULL.

--- a/src/query_processing/pac_expression_builder.cpp
+++ b/src/query_processing/pac_expression_builder.cpp
@@ -416,6 +416,34 @@ unique_ptr<Expression> BindPacAggregate(OptimizerExtensionInput &input, const st
 	return function_binder.BindAggregateFunction(func, std::move(children), nullptr, AggregateType::NON_DISTINCT);
 }
 
+PuPreAggregationInfo InsertPuPreAggregation(OptimizerExtensionInput &input, LogicalAggregate *agg,
+                                            vector<unique_ptr<Expression>> lower_expressions,
+                                            unique_ptr<Expression> pu_hash_expr) {
+	auto &binder = input.optimizer.binder;
+	idx_t lower_group_index = binder.GenerateTableIndex();
+	idx_t lower_agg_index = binder.GenerateTableIndex();
+	idx_t num_original_groups = agg->groups.size();
+
+	auto lower_agg = make_uniq<LogicalAggregate>(lower_group_index, lower_agg_index, std::move(lower_expressions));
+	for (auto &g : agg->groups) {
+		lower_agg->groups.push_back(g->Copy());
+	}
+	lower_agg->groups.push_back(std::move(pu_hash_expr));
+	lower_agg->children.push_back(std::move(agg->children[0]));
+	lower_agg->ResolveOperatorTypes();
+
+	for (idx_t i = 0; i < num_original_groups; i++) {
+		agg->groups[i] = make_uniq<BoundColumnRefExpression>(lower_agg->types[i], ColumnBinding(lower_group_index, i));
+	}
+
+	auto pu_hash_ref = make_uniq<BoundColumnRefExpression>(lower_agg->types[num_original_groups],
+	                                                       ColumnBinding(lower_group_index, num_original_groups));
+	auto *lower_agg_ptr = lower_agg.get();
+	agg->children[0] = std::move(lower_agg);
+
+	return {lower_agg_ptr, num_original_groups, lower_agg_index, std::move(pu_hash_ref)};
+}
+
 // Bind bit_or(hash_expr) with IS NOT NULL filter on filter_col_expr.
 unique_ptr<Expression> BindBitOrAggregate(OptimizerExtensionInput &input, unique_ptr<Expression> hash_expr,
                                           unique_ptr<Expression> filter_col_expr) {
@@ -1232,11 +1260,6 @@ void RewriteClipAggregates(OptimizerExtensionInput &input, unique_ptr<LogicalOpe
 			continue;
 		}
 
-		// Normal path: insert lower aggregate
-		auto &binder = input.optimizer.binder;
-		idx_t lower_group_index = binder.GenerateTableIndex();
-		idx_t lower_agg_index = binder.GenerateTableIndex();
-
 		// Identify the PU hash expression from the first pac aggregate's first child (hash arg)
 		unique_ptr<Expression> pu_hash_expr;
 		for (auto &expr : agg->expressions) {
@@ -1253,7 +1276,6 @@ void RewriteClipAggregates(OptimizerExtensionInput &input, unique_ptr<LogicalOpe
 			continue; // shouldn't happen
 		}
 		// Build lower aggregate expressions (plain DuckDB aggregates)
-		idx_t num_original_groups = agg->groups.size();
 		vector<unique_ptr<Expression>> lower_expressions;
 		for (idx_t i = 0; i < agg->expressions.size(); i++) {
 			auto &aggr = agg->expressions[i]->Cast<BoundAggregateExpression>();
@@ -1294,27 +1316,7 @@ void RewriteClipAggregates(OptimizerExtensionInput &input, unique_ptr<LogicalOpe
 			}
 		}
 
-		// Create lower aggregate node
-		auto lower_agg = make_uniq<LogicalAggregate>(lower_group_index, lower_agg_index, std::move(lower_expressions));
-
-		// Copy original groups + add PU hash as extra group
-		for (auto &g : agg->groups) {
-			lower_agg->groups.push_back(g->Copy());
-		}
-		lower_agg->groups.push_back(pu_hash_expr->Copy());
-
-		// Steal top's child → lower's child
-		lower_agg->children.push_back(std::move(agg->children[0]));
-		lower_agg->ResolveOperatorTypes();
-
-		// Rewrite top aggregate's groups to reference lower's group output
-		for (idx_t i = 0; i < num_original_groups; i++) {
-			auto gtype = agg->groups[i]->return_type;
-			agg->groups[i] = make_uniq<BoundColumnRefExpression>(gtype, ColumnBinding(lower_group_index, i));
-		}
-		// PU hash ref from lower's group output
-		auto pu_hash_ref = make_uniq<BoundColumnRefExpression>(pu_hash_expr->return_type,
-		                                                       ColumnBinding(lower_group_index, num_original_groups));
+		auto pre_agg = InsertPuPreAggregation(input, agg, std::move(lower_expressions), std::move(pu_hash_expr));
 
 		// Rewrite top aggregate's expressions to clip variants
 		for (idx_t i = 0; i < agg->expressions.size(); i++) {
@@ -1324,9 +1326,9 @@ void RewriteClipAggregates(OptimizerExtensionInput &input, unique_ptr<LogicalOpe
 			string orig = GetOriginalAggregate(pac_name);
 
 			// Reference to lower aggregate's result
-			auto lower_type = lower_agg->types[num_original_groups + 1 + i];
+			auto lower_type = pre_agg.lower_agg->types[pre_agg.num_original_groups + 1 + i];
 			unique_ptr<Expression> lower_ref =
-			    make_uniq<BoundColumnRefExpression>(lower_type, ColumnBinding(lower_agg_index, i));
+			    make_uniq<BoundColumnRefExpression>(lower_type, ColumnBinding(pre_agg.lower_agg_index, i));
 
 			// pac_clip_sum has integer + DECIMAL overloads but no FLOAT/DOUBLE.
 			// Cast FLOAT/DOUBLE to BIGINT so binding succeeds.
@@ -1343,10 +1345,8 @@ void RewriteClipAggregates(OptimizerExtensionInput &input, unique_ptr<LogicalOpe
 				clip_func = GetClipVariant(pac_name);
 			}
 			agg->expressions[i] =
-			    BindPacAggregate(input, clip_func, pu_hash_ref->Copy(), std::move(lower_ref), nullptr);
+			    BindPacAggregate(input, clip_func, pre_agg.pu_hash_ref->Copy(), std::move(lower_ref), nullptr);
 		}
-		// Set lower as top's child
-		agg->children[0] = std::move(lower_agg);
 		agg->ResolveOperatorTypes();
 	}
 }

--- a/src/utils/privacy_helpers.cpp
+++ b/src/utils/privacy_helpers.cpp
@@ -574,19 +574,28 @@ bool IsPacNoiseEnabled(ClientContext &context, bool default_value) {
 	}
 }
 
-string GetPrivacyMode(ClientContext &context) {
+static string GetNormalizedStringSetting(ClientContext &context, const string &setting_name,
+                                         const string &default_value) {
 	Value v;
-	if (!context.TryGetCurrentSetting("privacy_mode", v) || v.IsNull()) {
-		return "pac";
+	if (!context.TryGetCurrentSetting(setting_name, v) || v.IsNull()) {
+		return default_value;
 	}
 	string s = v.ToString();
 	std::transform(s.begin(), s.end(), s.begin(), [](unsigned char c) { return std::tolower(c); });
 	auto begin = s.find_first_not_of(" \t\n\r");
 	auto end = s.find_last_not_of(" \t\n\r");
 	if (begin == string::npos) {
-		return "pac";
+		return default_value;
 	}
 	return s.substr(begin, end - begin + 1);
+}
+
+string GetPrivacyMode(ClientContext &context) {
+	return GetNormalizedStringSetting(context, "privacy_mode", "pac");
+}
+
+string GetDPStrategy(ClientContext &context) {
+	return GetNormalizedStringSetting(context, "dp_strategy", "elastic");
 }
 
 double GetDpEpsilon(ClientContext &context, double default_value) {

--- a/test/sql/dp_sample_median.test
+++ b/test/sql/dp_sample_median.test
@@ -46,7 +46,7 @@ WITH vals AS (
 ), counters AS (
     SELECT list(v ORDER BY v) AS l FROM vals
 )
-SELECT abs(dp_smooth_median_noise(l, 10.0, 1e-6, 0.0, 100000.0)) > 10000.0
+SELECT abs(dp_smooth_median_noise(l, 10.0, 1e-6)) > 10000.0
 FROM counters;
 ----
 true

--- a/test/sql/dp_sample_median.test
+++ b/test/sql/dp_sample_median.test
@@ -46,7 +46,7 @@ WITH vals AS (
 ), counters AS (
     SELECT list(v ORDER BY v) AS l FROM vals
 )
-SELECT abs(dp_smooth_median_noise(l, 10.0, 1e-6, 8, 0.0, 100000.0)) > 10000.0
+SELECT abs(dp_smooth_median_noise(l, 10.0, 1e-6, 0.0, 100000.0)) > 10000.0
 FROM counters;
 ----
 true

--- a/test/sql/dp_sample_median.test
+++ b/test/sql/dp_sample_median.test
@@ -1,0 +1,152 @@
+# name: test/sql/dp_sample_median.test
+# description: DP sample-median strategy using PAC-style sample counters and smooth clipping
+# group: [sql]
+
+require privacy
+
+statement ok
+PRAGMA clear_privacy_metadata;
+
+statement ok
+SET threads = 1;
+
+statement ok
+SET privacy_seed = 42;
+
+statement ok
+SET privacy_mode = 'dp_elastic';
+
+statement ok
+SET dp_strategy = 'sample_median';
+
+statement ok
+SET privacy_noise = false;
+
+statement ok
+SET dp_epsilon = 1.0;
+
+statement ok
+SET dp_delta = 1e-6;
+
+query I
+SELECT current_setting('dp_strategy');
+----
+sample_median
+
+statement ok
+CREATE TABLE users AS SELECT i AS uid FROM range(1, 1001) t(i);
+
+statement ok
+CREATE TABLE events AS
+SELECT uid,
+       CASE WHEN uid % 2 = 0 THEN 'even' ELSE 'odd' END AS segment,
+       1.0::DOUBLE AS v
+FROM users;
+
+statement ok
+ALTER TABLE users ADD PRIVACY_KEY (uid);
+
+statement ok
+ALTER TABLE users SET PU;
+
+statement ok
+ALTER TABLE events ADD PRIVACY_LINK (uid) REFERENCES users(uid);
+
+# COUNT uses the 8-of-64 sample mask and median release. With noise disabled,
+# it is deterministic but still an estimator, not the exact count.
+query I
+SELECT COUNT(*) BETWEEN 900 AND 1100 FROM events;
+----
+true
+
+query II
+SELECT segment, COUNT(*) BETWEEN 450 AND 550
+FROM events
+GROUP BY segment
+ORDER BY segment;
+----
+even	true
+odd	true
+
+query I
+SELECT typeof(COUNT(*)) FROM events;
+----
+BIGINT
+
+# SUM requires both the per-tuple DP bound and the smooth clipping support threshold.
+statement ok
+RESET dp_sum_bound;
+
+statement error
+SELECT SUM(v) FROM events;
+----
+dp_sum_bound
+
+statement ok
+SET dp_sum_bound = 1.0;
+
+statement ok
+SET pac_clip_support = 0;
+
+statement error
+SELECT SUM(v) FROM events;
+----
+pac_clip_support
+
+statement ok
+SET pac_clip_support = 1;
+
+query I
+SELECT SUM(v) BETWEEN 900.0 AND 1100.0 FROM events;
+----
+true
+
+# Parallel execution exercises aggregate combine/finalize with buffered sample hashes.
+statement ok
+SET threads = 4;
+
+query I
+SELECT COUNT(*) BETWEEN 900 AND 1100 FROM events;
+----
+true
+
+query I
+SELECT SUM(v) BETWEEN 900.0 AND 1100.0 FROM events;
+----
+true
+
+statement ok
+SET threads = 1;
+
+query II
+SELECT segment, SUM(v) BETWEEN 450.0 AND 550.0
+FROM events
+GROUP BY segment
+ORDER BY segment;
+----
+even	true
+odd	true
+
+query I
+SELECT typeof(SUM(v)) FROM events;
+----
+DOUBLE
+
+# Group suppression uses the lower aggregate's one-row-per-PU shape, not per-lane support counts.
+statement ok
+SET privacy_min_group_count = 600;
+
+query II
+SELECT segment, COUNT(*) FROM events GROUP BY segment ORDER BY segment;
+----
+
+statement ok
+SET privacy_min_group_count = NULL;
+
+statement error
+SELECT AVG(v) FROM events;
+----
+AVG is not supported
+
+statement ok
+SET dp_strategy = 'elastic';

--- a/test/sql/dp_sample_median.test
+++ b/test/sql/dp_sample_median.test
@@ -33,6 +33,27 @@ SELECT current_setting('dp_strategy');
 ----
 sample_median
 
+# Smooth sensitivity treats affected as a sample-aggregate step size. One PU can
+# affect eight sample lanes, so an eight-lane median jump must be charged at
+# distance 0, not exponentially decayed as eight separate PU changes.
+statement ok
+SET privacy_noise = true;
+
+query I
+WITH vals AS (
+    SELECT CASE WHEN i < 39 THEN 0.0::FLOAT ELSE 100000.0::FLOAT END AS v
+    FROM range(64) t(i)
+), counters AS (
+    SELECT list(v ORDER BY v) AS l FROM vals
+)
+SELECT abs(dp_smooth_median_noise(l, 10.0, 1e-6, 8, 0.0, 100000.0)) > 10000.0
+FROM counters;
+----
+true
+
+statement ok
+SET privacy_noise = false;
+
 statement ok
 CREATE TABLE users AS SELECT i AS uid FROM range(1, 1001) t(i);
 


### PR DESCRIPTION
## Summary

This PR adds a DP sample-median strategy for `privacy_mode = dp_elastic` that reuses the PAC counter machinery to estimate instance-specific sensitivity from subsampled aggregate outputs.

At a high level, `dp_strategy = sample_median` rewrites supported aggregate queries into a two-level plan:

1. A lower pre-aggregation groups by the original query groups plus the privacy-unit hash. This collapses each privacy unit into one contribution per output group, matching the PAC clip shape and keeping `privacy_min_group_count` thresholding on the number of contributing privacy units.
2. The upper aggregate uses DP sample counter variants (`dp_sample_count`, `dp_sample_sum`, and clipped-sum counters) that map each privacy-unit hash into 8 of 64 sample lanes.
3. The final projection calls `dp_smooth_median_noise(...)`, which releases the median sample estimate with Laplace noise calibrated from smooth sensitivity over the sorted lane values.

The branch also extracts the shared lower pre-aggregation rewrite used by PAC clip and DP sample-median, so both paths now use the same helper for "original groups + PU hash" lowering instead of maintaining parallel implementations.

## Code Flow

### Compiler path

`src/compiler/dp_elastic_compiler.cpp` recognizes the sample-median DP strategy and routes supported aggregate queries through the sample-median rewrite.

The flow is:

1. Validate the query through the existing DP/PAC compatibility checks.
2. Reject unsupported aggregates for this strategy; sample median currently supports COUNT and SUM.
3. For SUM, clip input values using `dp_sum_bound` and require `pac_clip_support` so the lower per-PU contributions are routed through the clipped counter path.
4. Insert the shared lower PU pre-aggregation helper.
5. Replace top-level aggregates with PAC-style counter aggregate functions that return 64-lane lists.
6. Add a projection that applies `dp_smooth_median_noise(counters, epsilon, delta)`.
7. Keep group suppression before noising, using the lower PU rows as the support count.

### Shared pre-aggregation helper

`InsertPuPreAggregation` in `src/query_processing/pac_expression_builder.cpp` builds the common lower aggregate shape:

- group by original query groups
- also group by the original privacy-unit hash
- move the original aggregate child below the new lower aggregate
- rewrite the upper aggregate groups to reference the lower aggregate outputs
- expose the lower PU-hash reference for aggregate rewrites

PAC clip and DP sample-median both use this helper now. This keeps the important invariant explicit: the SQL grouping column is the original PU hash; the DP sample hash is only derived inside the aggregate update function.

### DP sample mask computation

Each lower pre-aggregated row represents one privacy unit for one output group. The aggregate receives that row with the original 64-bit PU hash. For the DP sample-median strategy, we do not use the original PAC 50 percent bit mask directly. Instead, we deterministically derive a new 64-bit sample mask from the PU hash.

`DpSampleHash(key_hash)` reads eight 6-bit chunks from the hash:

```cpp
lane_0 = (key_hash >> 0)  & 63
lane_1 = (key_hash >> 6)  & 63
lane_2 = (key_hash >> 12) & 63
lane_3 = (key_hash >> 18) & 63
lane_4 = (key_hash >> 24) & 63
lane_5 = (key_hash >> 30) & 63
lane_6 = (key_hash >> 36) & 63
lane_7 = (key_hash >> 42) & 63
```

Each chunk chooses one lane in `[0, 63]`. The sample mask is the OR of those lane bits:

```cpp
sample_hash = (1ULL << lane_0) |
              (1ULL << lane_1) |
              ... |
              (1ULL << lane_7)
```

So one privacy unit contributes to up to 8 of the 64 sample lanes. If two chunks choose the same lane, the mask has fewer than 8 distinct bits; this is intentional and gives the with-replacement sampling behavior. The per-lane inclusion probability is:

```text
p = 1 - (63 / 64)^8
```

The finalizer rescales each lane by `1 / p`, not by the PAC 2x correction. This is why DP sample-median has a separate finalization mode: the PAC counters are reused, but the sampling probability is different.

For clipped sums, the same transformed sample mask is used for counter updates, while the original PU hash is still available for the support/clipping bookkeeping. The SQL plan groups by the original PU hash; only the aggregate internals transform that hash into the DP sample mask.

### Smooth sensitivity release

`src/aggregates/dp_laplace_noise.cpp` adds `dp_smooth_median_noise(counters, epsilon, delta)`.

The function treats the incoming list as the 64 lane values `Z(1)..Z(64)` after sorting. It releases the lower median `Z(32)`. Sensitivity is derived only from rank gaps in those lane values, not from a base-table cardinality or explicit lower/upper output bounds.

For `m = 64` lanes and `q = 8` affected lanes per PU, the local sensitivity uses the conservative bound:

```text
LS_q(Z) <= Z(32 + q) - Z(32 - q)
```

The smooth envelope evaluates this for `q = 8, 16, 24` with exponential decay:

```text
S(Z) = max_k LS_{8(k+1)}(Z) * exp(-beta * k)
beta = epsilon / (2 * log(2 / delta))
```

Noise is then sampled with scale:

```text
2 * S(Z) / epsilon
```

## Behavioral Notes

- The sample-median strategy is still under `privacy_mode = dp_elastic`; PAC mode remains unchanged.
- `privacy_min_group_count` is enforced before noising, as in PAC clipping.
- The DP sample hash is internal to the aggregate. The lower pre-aggregation still groups by the original PU hash.
- SUM support requires clipping through `dp_sum_bound`, since smooth sensitivity does not remove the need to stabilize per-PU contributions before sampling.
- The smooth-median release no longer runs `COUNT(*)` over a source table and no longer uses table-derived lower/upper bounds.
