### PR TITLE
Add DP smooth sensitivity sample-median support

### DIFF
--- a/src/compiler/dp_elastic_compiler.cpp
+++ b/src/compiler/dp_elastic_compiler.cpp
@@ -1,6 +1,7 @@
 #include "compiler/dp_elastic_compiler.hpp"
 #include "aggregates/pac_aggregate.hpp"
 #include "utils/privacy_helpers.hpp"
+#include "compiler/pac_bitslice_compiler.hpp"
 #include "query_processing/pac_plan_traversal.hpp"
 #include "query_processing/pac_expression_builder.hpp"
 #include "privacy_debug.hpp"
@@ -480,40 +481,6 @@ static unique_ptr<Expression> BuildSupportKeyExpression(unique_ptr<LogicalOperat
 	return make_uniq<BoundColumnRefExpression>(col_type, ColumnBinding(get->table_index, proj_idx));
 }
 
-static unique_ptr<Expression> BuildSamplePuHashExpression(OptimizerExtensionInput &input,
-                                                          unique_ptr<LogicalOperator> &plan, const DPFKChain &chain,
-                                                          const PrivacyCompatibilityResult &check) {
-	if (chain.tables.size() > 2) {
-		throw InvalidInputException("dp_sample_median: only single-table PU queries and one-hop PRIVACY_LINK chains "
-		                            "are currently supported");
-	}
-	string source_table = chain.tables[0];
-	auto *get = FindGetForTable(plan, source_table);
-	if (!get) {
-		throw InternalException("dp_sample_median: could not find source table '" + source_table + "'");
-	}
-
-	vector<string> key_columns;
-	if (chain.tables.size() == 1) {
-		auto meta_it = check.table_metadata.find(source_table);
-		if (meta_it != check.table_metadata.end()) {
-			key_columns = meta_it->second.pks;
-		}
-		if (key_columns.empty()) {
-			key_columns = FindPacKey(input.context, source_table);
-		}
-		if (key_columns.empty()) {
-			throw InvalidInputException("dp_sample_median: privacy unit table '" + source_table +
-			                            "' has no PRIVACY_KEY columns");
-		}
-	} else {
-		key_columns.push_back(chain.fk_cols[0]);
-	}
-
-	auto binding = InsertHashProjectionAboveGet(input, plan, *get, key_columns, false);
-	return make_uniq<BoundColumnRefExpression>(LogicalType::UBIGINT, binding);
-}
-
 static optional_idx AddSupportAggregate(OptimizerExtensionInput &input, unique_ptr<LogicalOperator> &plan,
                                         LogicalAggregate *agg, const DPFKChain &chain, double threshold) {
 	if (threshold <= 0.0 || !std::isfinite(threshold)) {
@@ -720,13 +687,14 @@ WrapAvgRatioProjection(OptimizerExtensionInput &input, unique_ptr<LogicalOperato
 	return {ratio_idx, ratio_ptr};
 }
 
-static LogicalProjection *WrapSampleMedianProjection(OptimizerExtensionInput &input, unique_ptr<LogicalOperator> &plan,
-                                                     LogicalAggregate *agg, double epsilon, double delta,
-                                                     const vector<LogicalType> &output_types,
-                                                     LogicalOperator *insert_above) {
+static NoiseProjection WrapSampleMedianProjection(OptimizerExtensionInput &input, unique_ptr<LogicalOperator> &plan,
+                                                  LogicalAggregate *agg, const vector<double> &epsilons,
+                                                  const vector<double> &deltas, const vector<LogicalType> &output_types,
+                                                  LogicalOperator *insert_above) {
 	idx_t n_groups = agg->groups.size();
 	idx_t n_aggs = output_types.size();
-	double k = static_cast<double>(n_aggs);
+	D_ASSERT(epsilons.size() == n_aggs);
+	D_ASSERT(deltas.size() == n_aggs);
 
 	vector<unique_ptr<Expression>> proj_exprs;
 	proj_exprs.reserve(n_groups + n_aggs);
@@ -738,8 +706,8 @@ static LogicalProjection *WrapSampleMedianProjection(OptimizerExtensionInput &in
 		vector<unique_ptr<Expression>> children;
 		children.push_back(
 		    make_uniq<BoundColumnRefExpression>(agg->types[n_groups + ai], ColumnBinding(agg->aggregate_index, ai)));
-		children.push_back(make_uniq<BoundConstantExpression>(Value::DOUBLE(epsilon / k)));
-		children.push_back(make_uniq<BoundConstantExpression>(Value::DOUBLE(delta)));
+		children.push_back(make_uniq<BoundConstantExpression>(Value::DOUBLE(epsilons[ai])));
+		children.push_back(make_uniq<BoundConstantExpression>(Value::DOUBLE(deltas[ai])));
 		unique_ptr<Expression> noised = BindScalarLocal(input, "dp_smooth_median_noise", std::move(children));
 		if (output_types[ai] != LogicalType::DOUBLE) {
 			noised = BoundCastExpression::AddCastToType(input.context, std::move(noised), output_types[ai]);
@@ -757,6 +725,7 @@ static LogicalProjection *WrapSampleMedianProjection(OptimizerExtensionInput &in
 	projection->children.push_back(std::move(old_node));
 	projection->ResolveOperatorTypes();
 	auto *proj_ptr = projection.get();
+	auto proj_types = projection->types;
 	*slot = std::move(projection);
 
 	ColumnBindingReplacer replacer;
@@ -769,7 +738,7 @@ static LogicalProjection *WrapSampleMedianProjection(OptimizerExtensionInput &in
 	}
 	replacer.stop_operator = proj_ptr;
 	replacer.VisitOperator(*plan);
-	return proj_ptr;
+	return {proj_idx, proj_ptr, std::move(proj_types)};
 }
 
 static void RewriteAggregateToSampleMedian(OptimizerExtensionInput &input, LogicalAggregate *agg,
@@ -924,7 +893,6 @@ void CompileDPElasticQuery(const PrivacyCompatibilityResult &check, OptimizerExt
 void CompileDPSampleMedianQuery(const PrivacyCompatibilityResult &check, OptimizerExtensionInput &input,
                                 unique_ptr<LogicalOperator> &plan, const vector<string> &privacy_units,
                                 const string &query_hash) {
-	(void)privacy_units;
 	(void)query_hash;
 	PRIVACY_DEBUG_PRINT("[DP_SAMPLE_MEDIAN] CompileDPSampleMedianQuery: start");
 
@@ -945,21 +913,16 @@ void CompileDPSampleMedianQuery(const PrivacyCompatibilityResult &check, Optimiz
 	plan->ResolveOperatorTypes();
 	auto eligibility = CheckDPEligibility(plan, privacy_units, check);
 	auto *agg = eligibility.top_agg;
-	for (auto &expr : agg->expressions) {
-		auto &aggr = expr->Cast<BoundAggregateExpression>();
-		if (aggr.function.name == "avg") {
-			throw InvalidInputException("dp_sample_median: AVG is not supported");
-		}
-		if (aggr.function.name != "count" && aggr.function.name != "count_star" && aggr.function.name != "sum") {
-			throw InvalidInputException("dp_sample_median: only COUNT and SUM aggregates are supported");
-		}
-	}
+
+	auto avg_infos = RewriteAvgAggregates(input, agg);
+	idx_t n_original_aggs = agg->expressions.size() - avg_infos.size();
+	idx_t n_groups = agg->groups.size();
 
 	double sum_bound = 0.0;
 	bool has_sum = AggregateContainsSum(agg);
 	if (has_sum) {
 		if (!TryGetDpSumBound(input.context, sum_bound)) {
-			throw InvalidInputException("dp_sample_median: dp_sum_bound must be set for SUM aggregates");
+			throw InvalidInputException("dp_sample_median: dp_sum_bound must be set for SUM and AVG aggregates");
 		}
 		if (sum_bound <= 0.0 || !std::isfinite(sum_bound)) {
 			throw InvalidInputException("dp_sample_median: dp_sum_bound must be a positive finite number");
@@ -967,20 +930,42 @@ void CompileDPSampleMedianQuery(const PrivacyCompatibilityResult &check, Optimiz
 		Value clip_support_val;
 		if (!input.context.TryGetCurrentSetting("pac_clip_support", clip_support_val) || clip_support_val.IsNull() ||
 		    clip_support_val.GetValue<int64_t>() <= 0) {
-			throw InvalidInputException("dp_sample_median: pac_clip_support must be set for SUM aggregates");
+			throw InvalidInputException("dp_sample_median: pac_clip_support must be set for SUM and AVG aggregates");
 		}
 		ClipSumInputs(input, agg, sum_bound);
 	}
 
 	vector<LogicalType> output_types;
 	output_types.reserve(agg->expressions.size());
-	for (auto &expr : agg->expressions) {
-		auto &aggr = expr->Cast<BoundAggregateExpression>();
-		output_types.push_back(aggr.return_type);
+	std::unordered_set<idx_t> avg_positions;
+	for (auto &info : avg_infos) {
+		avg_positions.insert(info.sum_pos);
+		avg_positions.insert(info.count_pos);
+	}
+	double k = static_cast<double>(n_original_aggs);
+	vector<double> epsilons;
+	vector<double> deltas;
+	epsilons.reserve(agg->expressions.size());
+	deltas.reserve(agg->expressions.size());
+	for (idx_t ai = 0; ai < agg->expressions.size(); ai++) {
+		auto &aggr = agg->expressions[ai]->Cast<BoundAggregateExpression>();
+		output_types.push_back(avg_positions.count(ai) ? LogicalType::DOUBLE : aggr.return_type);
+	}
+	for (idx_t ai = 0; ai < agg->expressions.size(); ai++) {
+		double split = avg_positions.count(ai) ? (2.0 * k) : k;
+		epsilons.push_back(epsilon / split);
+		deltas.push_back(delta / split);
 	}
 
-	auto pu_hash_expr = BuildSamplePuHashExpression(input, plan, eligibility.fk_chain, check);
-	RewriteAggregateToSampleMedian(input, agg, std::move(pu_hash_expr));
+	auto pu_setup = PreparePlanForPUHashing(check, input, plan, privacy_units);
+	auto hash_infos = BuildPUHashExpressionsForAggregates(input, plan, pu_setup.pu_names, check, pu_setup.cte_map);
+	if (hash_infos.empty()) {
+		throw InvalidInputException("dp_sample_median: no aggregate with a reachable privacy-unit hash found");
+	}
+	if (hash_infos.size() != 1 || hash_infos[0].aggregate != agg) {
+		throw InvalidInputException("dp_sample_median: expected exactly one privacy-unit aggregate");
+	}
+	RewriteAggregateToSampleMedian(input, agg, std::move(hash_infos[0].hash_expr));
 
 	LogicalOperator *projection_anchor = agg;
 	Value threshold_val;
@@ -995,7 +980,10 @@ void CompileDPSampleMedianQuery(const PrivacyCompatibilityResult &check, Optimiz
 		projection_anchor = ApplySupportFilter(input, plan, agg, support_pos, support_threshold);
 	}
 
-	WrapSampleMedianProjection(input, plan, agg, epsilon, delta, output_types, projection_anchor);
+	auto noise_proj = WrapSampleMedianProjection(input, plan, agg, epsilons, deltas, output_types, projection_anchor);
+	if (!avg_infos.empty()) {
+		WrapAvgRatioProjection(input, plan, noise_proj, avg_infos, n_groups, n_original_aggs, noise_proj.proj_ptr);
+	}
 
 #if PRIVACY_DEBUG
 	PRIVACY_DEBUG_PRINT("=== PLAN AFTER DP_SAMPLE_MEDIAN TRANSFORMATION ===");

--- a/src/compiler/dp_elastic_compiler.cpp
+++ b/src/compiler/dp_elastic_compiler.cpp
@@ -162,7 +162,7 @@ static unique_ptr<LogicalOperator> *FindSlotForOperator(unique_ptr<LogicalOperat
 // ----------------------------------------------------------------------------
 
 static DPFKChain ExtractFKChain(const PrivacyCompatibilityResult &check, const vector<LogicalGet *> &gets,
-                                const vector<string> &privacy_units) {
+                                const vector<string> &privacy_units, bool include_fk_cols) {
 	(void)privacy_units;
 
 	// Self-join check: no table name may appear more than once in the plan
@@ -234,6 +234,9 @@ static DPFKChain ExtractFKChain(const PrivacyCompatibilityResult &check, const v
 	// Build fk_cols: for each consecutive pair in the chain, find the FK column
 	DPFKChain chain;
 	chain.tables = *longest_path;
+	if (!include_fk_cols) {
+		return chain;
+	}
 	chain.fk_cols.reserve(chain.tables.size() - 1);
 
 	for (idx_t i = 0; i + 1 < chain.tables.size(); i++) {
@@ -268,19 +271,7 @@ static DPFKChain ExtractFKChain(const PrivacyCompatibilityResult &check, const v
 // Eligibility check (Phase D: allows linear FK join chains)
 // ----------------------------------------------------------------------------
 
-struct DPEligibility {
-	LogicalAggregate *top_agg;
-	DPFKChain fk_chain;
-};
-
-static DPEligibility CheckDPEligibility(unique_ptr<LogicalOperator> &plan, const vector<string> &privacy_units,
-                                        const PrivacyCompatibilityResult &check) {
-	vector<LogicalGet *> gets;
-	CollectGetNodes(plan.get(), gets);
-
-	// Validates self-joins, PU count, and linear chain structure; returns the chain
-	DPFKChain fk_chain = ExtractFKChain(check, gets, privacy_units);
-
+static LogicalAggregate *CheckDPAggregates(unique_ptr<LogicalOperator> &plan) {
 	vector<LogicalAggregate *> aggs;
 	FindAllAggregates(plan, aggs);
 	if (aggs.size() != 1) {
@@ -307,7 +298,21 @@ static DPEligibility CheckDPEligibility(unique_ptr<LogicalOperator> &plan, const
 			                            a.children[0]->return_type.ToString() + "')");
 		}
 	}
-	return {agg, std::move(fk_chain)};
+	return agg;
+}
+
+static DPFKChain ExtractDPElasticFKChain(unique_ptr<LogicalOperator> &plan, const vector<string> &privacy_units,
+                                         const PrivacyCompatibilityResult &check) {
+	vector<LogicalGet *> gets;
+	CollectGetNodes(plan.get(), gets);
+	return ExtractFKChain(check, gets, privacy_units, true);
+}
+
+static void ValidateDPFKChainShape(unique_ptr<LogicalOperator> &plan, const vector<string> &privacy_units,
+                                   const PrivacyCompatibilityResult &check) {
+	vector<LogicalGet *> gets;
+	CollectGetNodes(plan.get(), gets);
+	ExtractFKChain(check, gets, privacy_units, false);
 }
 
 // ----------------------------------------------------------------------------
@@ -537,6 +542,45 @@ struct NoiseProjection {
 	}
 };
 
+static std::unordered_set<idx_t> BuildAvgComponentSet(const vector<AvgInfo> &avg_infos) {
+	std::unordered_set<idx_t> avg_components;
+	for (auto &info : avg_infos) {
+		avg_components.insert(info.sum_pos);
+		avg_components.insert(info.count_pos);
+	}
+	return avg_components;
+}
+
+static NoiseProjection InsertProjectionAndRemap(unique_ptr<LogicalOperator> &plan,
+                                                unique_ptr<LogicalProjection> projection, LogicalOperator *insert_above,
+                                                idx_t proj_idx, idx_t source_group_idx, idx_t source_agg_idx,
+                                                idx_t n_groups, idx_t n_aggs, idx_t source_agg_offset,
+                                                const string &error_message) {
+	auto *slot = FindSlotForOperator(plan, insert_above);
+	if (!slot) {
+		throw InternalException(error_message);
+	}
+	auto old_node = std::move(*slot);
+	projection->children.push_back(std::move(old_node));
+	projection->ResolveOperatorTypes();
+	auto *proj_ptr = projection.get();
+	auto proj_types = projection->types;
+	*slot = std::move(projection);
+
+	ColumnBindingReplacer replacer;
+	for (idx_t gi = 0; gi < n_groups; gi++) {
+		replacer.replacement_bindings.emplace_back(ColumnBinding(source_group_idx, gi), ColumnBinding(proj_idx, gi));
+	}
+	for (idx_t ai = 0; ai < n_aggs; ai++) {
+		replacer.replacement_bindings.emplace_back(ColumnBinding(source_agg_idx, source_agg_offset + ai),
+		                                           ColumnBinding(proj_idx, n_groups + ai));
+	}
+	replacer.stop_operator = proj_ptr;
+	replacer.VisitOperator(*plan);
+
+	return {proj_idx, proj_ptr, std::move(proj_types)};
+}
+
 static NoiseProjection WrapAggregateWithLaplace(OptimizerExtensionInput &input, unique_ptr<LogicalOperator> &plan,
                                                 LogicalAggregate *agg, LogicalOperator *insert_above,
                                                 const vector<double> &agg_scales) {
@@ -576,30 +620,8 @@ static NoiseProjection WrapAggregateWithLaplace(OptimizerExtensionInput &input, 
 
 	idx_t proj_idx = input.optimizer.binder.GenerateTableIndex();
 	auto projection = make_uniq<LogicalProjection>(proj_idx, std::move(proj_exprs));
-
-	auto *slot = FindSlotForOperator(plan, insert_above);
-	if (!slot) {
-		throw InternalException("dp_elastic: could not locate noise insertion slot in plan");
-	}
-	auto old_node = std::move(*slot);
-	projection->children.push_back(std::move(old_node));
-	projection->ResolveOperatorTypes();
-	LogicalProjection *proj_ptr = projection.get();
-	auto proj_types = projection->types;
-	*slot = std::move(projection);
-
-	// Remap bindings above the inserted projection
-	ColumnBindingReplacer replacer;
-	for (idx_t gi = 0; gi < n_groups; gi++) {
-		replacer.replacement_bindings.emplace_back(ColumnBinding(group_idx, gi), ColumnBinding(proj_idx, gi));
-	}
-	for (idx_t ai = 0; ai < n_aggs; ai++) {
-		replacer.replacement_bindings.emplace_back(ColumnBinding(agg_idx, ai), ColumnBinding(proj_idx, n_groups + ai));
-	}
-	replacer.stop_operator = proj_ptr;
-	replacer.VisitOperator(*plan);
-
-	return {proj_idx, proj_ptr, std::move(proj_types)};
+	return InsertProjectionAndRemap(plan, std::move(projection), insert_above, proj_idx, group_idx, agg_idx, n_groups,
+	                                n_aggs, 0, "dp_elastic: could not locate noise insertion slot in plan");
 }
 
 // ----------------------------------------------------------------------------
@@ -616,8 +638,9 @@ WrapAvgRatioProjection(OptimizerExtensionInput &input, unique_ptr<LogicalOperato
 	D_ASSERT(!avg_infos.empty());
 
 	// Build lookup: original-agg-position → AvgInfo
-	std::unordered_map<idx_t, const AvgInfo *> avg_lookup;
+	vector<const AvgInfo *> avg_lookup(n_original_aggs, nullptr);
 	for (auto &info : avg_infos) {
+		D_ASSERT(info.sum_pos < n_original_aggs);
 		avg_lookup[info.sum_pos] = &info;
 	}
 
@@ -632,15 +655,15 @@ WrapAvgRatioProjection(OptimizerExtensionInput &input, unique_ptr<LogicalOperato
 
 	// For each original agg position: pass-through or compute AVG ratio
 	for (idx_t ai = 0; ai < n_original_aggs; ai++) {
-		auto it = avg_lookup.find(ai);
-		if (it == avg_lookup.end()) {
+		auto *avg_info = avg_lookup[ai];
+		if (!avg_info) {
 			// Non-AVG: pass the noised value through
 			auto col_type = noise_proj.proj_types[n_groups + ai];
 			proj_exprs.push_back(
 			    make_uniq<BoundColumnRefExpression>(col_type, ColumnBinding(noise_proj.proj_idx, n_groups + ai)));
 		} else {
 			// AVG: compute CAST(noised_sum AS DOUBLE) / greatest(CAST(noised_count AS DOUBLE), 1.0)
-			const AvgInfo &info = *it->second;
+			const AvgInfo &info = *avg_info;
 			auto sum_type = noise_proj.proj_types[n_groups + info.sum_pos];
 			auto cnt_type = noise_proj.proj_types[n_groups + info.count_pos];
 			auto sum_ref = make_uniq<BoundColumnRefExpression>(
@@ -659,32 +682,10 @@ WrapAvgRatioProjection(OptimizerExtensionInput &input, unique_ptr<LogicalOperato
 
 	idx_t ratio_idx = input.optimizer.binder.GenerateTableIndex();
 	auto ratio_proj = make_uniq<LogicalProjection>(ratio_idx, std::move(proj_exprs));
-
-	auto *slot = FindSlotForOperator(plan, insert_above);
-	if (!slot) {
-		throw InternalException("dp_elastic: could not locate insert point for AVG ratio projection");
-	}
-	auto old_node = std::move(*slot);
-	ratio_proj->children.push_back(std::move(old_node));
-	ratio_proj->ResolveOperatorTypes();
-	auto *ratio_ptr = ratio_proj.get();
-	*slot = std::move(ratio_proj);
-
-	// Remap upstream references: noise_proj group/agg cols → ratio_proj cols
-	ColumnBindingReplacer replacer;
-	for (idx_t gi = 0; gi < n_groups; gi++) {
-		replacer.replacement_bindings.emplace_back(ColumnBinding(noise_proj.proj_idx, gi),
-		                                           ColumnBinding(ratio_idx, gi));
-	}
-	for (idx_t ai = 0; ai < n_original_aggs; ai++) {
-		replacer.replacement_bindings.emplace_back(ColumnBinding(noise_proj.proj_idx, n_groups + ai),
-		                                           ColumnBinding(ratio_idx, n_groups + ai));
-	}
-	// Extra COUNT(*) positions are consumed inside ratio_proj — no upstream references
-	replacer.stop_operator = ratio_ptr;
-	replacer.VisitOperator(*plan);
-
-	return {ratio_idx, ratio_ptr};
+	auto inserted = InsertProjectionAndRemap(plan, std::move(ratio_proj), insert_above, ratio_idx, noise_proj.proj_idx,
+	                                         noise_proj.proj_idx, n_groups, n_original_aggs, n_groups,
+	                                         "dp_elastic: could not locate insert point for AVG ratio projection");
+	return {inserted.proj_idx, inserted.proj_ptr};
 }
 
 static NoiseProjection WrapSampleMedianProjection(OptimizerExtensionInput &input, unique_ptr<LogicalOperator> &plan,
@@ -717,28 +718,9 @@ static NoiseProjection WrapSampleMedianProjection(OptimizerExtensionInput &input
 
 	idx_t proj_idx = input.optimizer.binder.GenerateTableIndex();
 	auto projection = make_uniq<LogicalProjection>(proj_idx, std::move(proj_exprs));
-	auto *slot = FindSlotForOperator(plan, insert_above);
-	if (!slot) {
-		throw InternalException("dp_sample_median: could not locate aggregate slot for median projection");
-	}
-	auto old_node = std::move(*slot);
-	projection->children.push_back(std::move(old_node));
-	projection->ResolveOperatorTypes();
-	auto *proj_ptr = projection.get();
-	auto proj_types = projection->types;
-	*slot = std::move(projection);
-
-	ColumnBindingReplacer replacer;
-	for (idx_t gi = 0; gi < n_groups; gi++) {
-		replacer.replacement_bindings.emplace_back(ColumnBinding(agg->group_index, gi), ColumnBinding(proj_idx, gi));
-	}
-	for (idx_t ai = 0; ai < n_aggs; ai++) {
-		replacer.replacement_bindings.emplace_back(ColumnBinding(agg->aggregate_index, ai),
-		                                           ColumnBinding(proj_idx, n_groups + ai));
-	}
-	replacer.stop_operator = proj_ptr;
-	replacer.VisitOperator(*plan);
-	return {proj_idx, proj_ptr, std::move(proj_types)};
+	return InsertProjectionAndRemap(plan, std::move(projection), insert_above, proj_idx, agg->group_index,
+	                                agg->aggregate_index, n_groups, n_aggs, 0,
+	                                "dp_sample_median: could not locate aggregate slot for median projection");
 }
 
 static void RewriteAggregateToSampleMedian(OptimizerExtensionInput &input, LogicalAggregate *agg,
@@ -803,8 +785,8 @@ void CompileDPElasticQuery(const PrivacyCompatibilityResult &check, OptimizerExt
 
 	plan->ResolveOperatorTypes();
 
-	auto eligibility = CheckDPEligibility(plan, privacy_units, check);
-	auto *agg = eligibility.top_agg;
+	auto fk_chain = ExtractDPElasticFKChain(plan, privacy_units, check);
+	auto *agg = CheckDPAggregates(plan);
 
 	// Rewrite AVG(x) → SUM(x) + COUNT(*) before bound/clipping checks.
 	// Each AVG uses ε/2 per component so the combined cost is still ε-DP.
@@ -817,19 +799,14 @@ void CompileDPElasticQuery(const PrivacyCompatibilityResult &check, OptimizerExt
 	bool apply_support_filter =
 	    input.context.TryGetCurrentSetting("privacy_min_group_count", threshold_val) && !threshold_val.IsNull() &&
 	    (support_threshold = threshold_val.GetValue<double>()) > 0.0 && std::isfinite(support_threshold);
-	auto support_pos = AddSupportAggregate(input, plan, agg, eligibility.fk_chain, support_threshold);
+	auto support_pos = AddSupportAggregate(input, plan, agg, fk_chain, support_threshold);
 	idx_t n_dp_aggs = support_pos.IsValid() ? support_pos.GetIndex() : agg->expressions.size();
 	LogicalOperator *noise_anchor = agg;
 	if (apply_support_filter) {
 		noise_anchor = ApplySupportFilter(input, plan, agg, support_pos.GetIndex(), support_threshold);
 	}
 
-	// Build fast lookup: which positions are AVG-derived (need budget split)?
-	std::unordered_set<idx_t> avg_positions;
-	for (auto &info : avg_infos) {
-		avg_positions.insert(info.sum_pos);
-		avg_positions.insert(info.count_pos);
-	}
+	auto avg_components = BuildAvgComponentSet(avg_infos);
 
 	double sum_bound = 0.0;
 	bool has_sum = AggregateContainsSum(agg); // SUM or AVG→SUM
@@ -846,7 +823,7 @@ void CompileDPElasticQuery(const PrivacyCompatibilityResult &check, OptimizerExt
 	}
 
 	// Compute smooth elastic sensitivity using the required dp_delta setting
-	double es = ComputeElasticSensitivity(input.context, eligibility.fk_chain, epsilon);
+	double es = ComputeElasticSensitivity(input.context, fk_chain, epsilon);
 
 	// When privacy_noise=false the compilation pipeline still runs (clipping, FK chain)
 	// but Laplace scale is zeroed → dp_laplace_noise returns the value unchanged.
@@ -868,7 +845,7 @@ void CompileDPElasticQuery(const PrivacyCompatibilityResult &check, OptimizerExt
 		if (k > 1.0) {
 			scale *= k; // budget split across user-visible aggregates
 		}
-		if (avg_positions.count(ai)) {
+		if (avg_components.count(ai)) {
 			scale *= 2.0; // additional split: each AVG component uses half its allocation
 		}
 		agg_scales.push_back(scale);
@@ -911,8 +888,8 @@ void CompileDPSampleMedianQuery(const PrivacyCompatibilityResult &check, Optimiz
 	}
 
 	plan->ResolveOperatorTypes();
-	auto eligibility = CheckDPEligibility(plan, privacy_units, check);
-	auto *agg = eligibility.top_agg;
+	ValidateDPFKChainShape(plan, privacy_units, check);
+	auto *agg = CheckDPAggregates(plan);
 
 	auto avg_infos = RewriteAvgAggregates(input, agg);
 	idx_t n_original_aggs = agg->expressions.size() - avg_infos.size();
@@ -937,11 +914,7 @@ void CompileDPSampleMedianQuery(const PrivacyCompatibilityResult &check, Optimiz
 
 	vector<LogicalType> output_types;
 	output_types.reserve(agg->expressions.size());
-	std::unordered_set<idx_t> avg_positions;
-	for (auto &info : avg_infos) {
-		avg_positions.insert(info.sum_pos);
-		avg_positions.insert(info.count_pos);
-	}
+	auto avg_components = BuildAvgComponentSet(avg_infos);
 	double k = static_cast<double>(n_original_aggs);
 	vector<double> epsilons;
 	vector<double> deltas;
@@ -949,10 +922,8 @@ void CompileDPSampleMedianQuery(const PrivacyCompatibilityResult &check, Optimiz
 	deltas.reserve(agg->expressions.size());
 	for (idx_t ai = 0; ai < agg->expressions.size(); ai++) {
 		auto &aggr = agg->expressions[ai]->Cast<BoundAggregateExpression>();
-		output_types.push_back(avg_positions.count(ai) ? LogicalType::DOUBLE : aggr.return_type);
-	}
-	for (idx_t ai = 0; ai < agg->expressions.size(); ai++) {
-		double split = avg_positions.count(ai) ? (2.0 * k) : k;
+		output_types.push_back(avg_components.count(ai) ? LogicalType::DOUBLE : aggr.return_type);
+		double split = avg_components.count(ai) ? (2.0 * k) : k;
 		epsilons.push_back(epsilon / split);
 		deltas.push_back(delta / split);
 	}

--- a/src/compiler/pac_bitslice_compiler.cpp
+++ b/src/compiler/pac_bitslice_compiler.cpp
@@ -448,9 +448,11 @@ static CTEHashMatch FindCTEHashSource(LogicalOperator *op, const string &pu_tabl
 	return CTEHashMatch();
 }
 
-void ModifyPlanWithPU(OptimizerExtensionInput &input, unique_ptr<LogicalOperator> &plan,
-                      const vector<string> &pu_table_names, const PrivacyCompatibilityResult &check,
-                      const CTETableMap &cte_map, PacAggregateInfoMap &pac_agg_info) {
+vector<PacAggregateHashInfo> BuildPUHashExpressionsForAggregates(OptimizerExtensionInput &input,
+                                                                 unique_ptr<LogicalOperator> &plan,
+                                                                 const vector<string> &pu_table_names,
+                                                                 const PrivacyCompatibilityResult &check,
+                                                                 const CTETableMap &cte_map) {
 	// Find ALL aggregate nodes in the plan first
 	vector<LogicalAggregate *> all_aggregates;
 	FindAllAggregates(plan, all_aggregates);
@@ -511,6 +513,7 @@ void ModifyPlanWithPU(OptimizerExtensionInput &input, unique_ptr<LogicalOperator
 	std::unordered_map<idx_t, ColumnBinding> cte_hash_cache;
 
 	// For each target aggregate, build hash expressions and modify it
+	vector<PacAggregateHashInfo> result;
 	for (auto *target_agg : target_aggregates) {
 		// Build hash expressions for each privacy unit
 		vector<unique_ptr<Expression>> hash_exprs;
@@ -744,18 +747,85 @@ void ModifyPlanWithPU(OptimizerExtensionInput &input, unique_ptr<LogicalOperator
 			hash_binding = combined_hash_expr->Cast<BoundColumnRefExpression>().binding;
 		}
 
+		result.push_back({target_agg, std::move(combined_hash_expr), hash_binding, correction});
+	}
+	return result;
+}
+
+void ModifyPlanWithPU(OptimizerExtensionInput &input, unique_ptr<LogicalOperator> &plan,
+                      const vector<string> &pu_table_names, const PrivacyCompatibilityResult &check,
+                      const CTETableMap &cte_map, PacAggregateInfoMap &pac_agg_info) {
+	auto hash_infos = BuildPUHashExpressionsForAggregates(input, plan, pu_table_names, check, cte_map);
+	for (auto &hash_info : hash_infos) {
 		// Modify this aggregate with PAC functions
-		ModifyAggregatesWithPacFunctions(input, target_agg, combined_hash_expr, plan, correction);
+		ModifyAggregatesWithPacFunctions(input, hash_info.aggregate, hash_info.hash_expr, plan, hash_info.correction);
 
 		// Record metadata for the categorical rewriter
-		if (hash_binding.table_index != DConstants::INVALID_INDEX) {
+		if (hash_info.hash_binding.table_index != DConstants::INVALID_INDEX) {
 			PacAggregateInfo info;
-			info.aggregate_index = target_agg->aggregate_index;
-			info.group_index = target_agg->group_index;
-			info.hash_binding = hash_binding;
-			pac_agg_info[target_agg->aggregate_index] = info;
+			info.aggregate_index = hash_info.aggregate->aggregate_index;
+			info.group_index = hash_info.aggregate->group_index;
+			info.hash_binding = hash_info.hash_binding;
+			pac_agg_info[hash_info.aggregate->aggregate_index] = info;
 		}
 	}
+}
+
+PacPUHashingSetup PreparePlanForPUHashing(const PrivacyCompatibilityResult &check, OptimizerExtensionInput &input,
+                                          unique_ptr<LogicalOperator> &plan, const vector<string> &privacy_units) {
+	// Build the CTE table map once — used for both routing and aggregate filtering
+	auto cte_map = BuildAndResolveCTETableMap(plan.get());
+
+	// Determine if a PU table is reachable from the plan (directly scanned, via CTE, or via FK+CTE)
+	bool pu_present_in_tree = !check.scanned_pu_tables.empty();
+	bool pu_via_cte = false;
+
+	if (!pu_present_in_tree) {
+		for (auto &cte_kv : cte_map) {
+			auto &cte_tables = cte_kv.second;
+			for (auto &pu : privacy_units) {
+				if (cte_tables.count(pu) > 0) {
+					pu_via_cte = true;
+					break;
+				}
+			}
+			if (!pu_via_cte) {
+				for (auto &fk_kv : check.fk_paths) {
+					if (cte_tables.count(fk_kv.first) > 0) {
+						pu_via_cte = true;
+						break;
+					}
+				}
+			}
+			if (pu_via_cte) {
+				break;
+			}
+		}
+		pu_present_in_tree = pu_via_cte;
+	}
+
+	if (!pu_present_in_tree && !check.fk_paths.empty()) {
+		// PU not reachable — add FK joins so plan has all tables needed
+		string start_table;
+		vector<string> target_pus;
+		vector<string> gets_present, gets_missing;
+		PopulateGetsFromFKPath(check, gets_present, gets_missing, start_table, target_pus);
+
+		auto it = check.fk_paths.find(start_table);
+		if (it == check.fk_paths.end() || it->second.empty()) {
+			throw InvalidInputException("PAC compiler: expected fk_path for start table " + start_table);
+		}
+
+		// Deduplicate missing tables
+		std::unordered_set<string> missing_set(gets_missing.begin(), gets_missing.end());
+		vector<string> unique_gets_missing(missing_set.begin(), missing_set.end());
+		std::sort(unique_gets_missing.begin(), unique_gets_missing.end());
+
+		AddMissingFKJoins(check, input, plan, unique_gets_missing, gets_present, it->second, privacy_units, cte_map);
+	}
+
+	auto pu_names = (pu_present_in_tree && !pu_via_cte) ? check.scanned_pu_tables : privacy_units;
+	return {std::move(cte_map), std::move(pu_names)};
 }
 
 void CompilePacBitsliceQuery(const PrivacyCompatibilityResult &check, OptimizerExtensionInput &input,
@@ -801,65 +871,14 @@ void CompilePacBitsliceQuery(const PrivacyCompatibilityResult &check, OptimizerE
 	// b.2) we join the chain of tables from the scanned table to each PU table (deduplicating)
 	// b.3) we hash the PK(s) as in a) and AND them together
 
-	// Build the CTE table map once — used for both routing and aggregate filtering
-	auto cte_map = BuildAndResolveCTETableMap(plan.get());
-
-	// Determine if a PU table is reachable from the plan (directly scanned, via CTE, or via FK+CTE)
-	bool pu_present_in_tree = !check.scanned_pu_tables.empty();
-	bool pu_via_cte = false;
-
-	if (!pu_present_in_tree) {
-		for (auto &cte_kv : cte_map) {
-			auto &cte_tables = cte_kv.second;
-			for (auto &pu : privacy_units) {
-				if (cte_tables.count(pu) > 0) {
-					pu_via_cte = true;
-					break;
-				}
-			}
-			if (!pu_via_cte) {
-				for (auto &fk_kv : check.fk_paths) {
-					if (cte_tables.count(fk_kv.first) > 0) {
-						pu_via_cte = true;
-						break;
-					}
-				}
-			}
-			if (pu_via_cte) {
-				break;
-			}
-		}
-		pu_present_in_tree = pu_via_cte;
-	}
 #if PRIVACY_DEBUG
 	PRIVACY_DEBUG_PRINT("=== PLAN BEFORE PAC TRANSFORMATION ===");
 	plan->Print();
 #endif
-	if (!pu_present_in_tree && !check.fk_paths.empty()) {
-		// Phase 1: PU not reachable — add FK joins so plan has all tables needed
-		string start_table;
-		vector<string> target_pus;
-		vector<string> gets_present, gets_missing;
-		PopulateGetsFromFKPath(check, gets_present, gets_missing, start_table, target_pus);
-
-		auto it = check.fk_paths.find(start_table);
-		if (it == check.fk_paths.end() || it->second.empty()) {
-			throw InvalidInputException("PAC compiler: expected fk_path for start table " + start_table);
-		}
-
-		// Deduplicate missing tables
-		std::unordered_set<string> missing_set(gets_missing.begin(), gets_missing.end());
-		vector<string> unique_gets_missing(missing_set.begin(), missing_set.end());
-		std::sort(unique_gets_missing.begin(), unique_gets_missing.end());
-
-		AddMissingFKJoins(check, input, plan, unique_gets_missing, gets_present, it->second, privacy_units, cte_map);
-	}
+	auto pu_setup = PreparePlanForPUHashing(check, input, plan, privacy_units);
 	// Phase 2: always transform aggregates via unified path
 	PacAggregateInfoMap pac_agg_info;
-	{
-		auto &pu_names = (pu_present_in_tree && !pu_via_cte) ? check.scanned_pu_tables : privacy_units;
-		ModifyPlanWithPU(input, plan, pu_names, check, cte_map, pac_agg_info);
-	}
+	ModifyPlanWithPU(input, plan, pu_setup.pu_names, check, pu_setup.cte_map, pac_agg_info);
 
 	// ============================================================================
 	// CATEGORICAL QUERY HANDLING
@@ -886,8 +905,7 @@ void CompilePacBitsliceQuery(const PrivacyCompatibilityResult &check, OptimizerE
 	{
 		Value clip_val;
 		if (input.context.TryGetCurrentSetting("pac_clip_support", clip_val) && !clip_val.IsNull()) {
-			auto &pu_names = (pu_present_in_tree && !pu_via_cte) ? check.scanned_pu_tables : privacy_units;
-			RewriteClipAggregates(input, plan, check, pu_names);
+			RewriteClipAggregates(input, plan, check, pu_setup.pu_names);
 		}
 	}
 

--- a/src/include/compiler/pac_bitslice_compiler.hpp
+++ b/src/include/compiler/pac_bitslice_compiler.hpp
@@ -9,12 +9,35 @@
 #include "duckdb/optimizer/optimizer_extension.hpp"
 #include "duckdb/planner/logical_operator.hpp"
 #include "metadata/privacy_compatibility_check.hpp"
+#include "categorical/pac_categorical_detection.hpp"
 #include "query_processing/pac_plan_traversal.hpp"
 
 namespace duckdb {
 
 // forward-declare LogicalGet to avoid including heavy headers in this header
 class LogicalGet;
+class LogicalAggregate;
+
+struct PacPUHashingSetup {
+	CTETableMap cte_map;
+	vector<string> pu_names;
+
+	PacPUHashingSetup(CTETableMap cte_map, vector<string> pu_names)
+	    : cte_map(std::move(cte_map)), pu_names(std::move(pu_names)) {
+	}
+};
+
+struct PacAggregateHashInfo {
+	LogicalAggregate *aggregate;
+	unique_ptr<Expression> hash_expr;
+	ColumnBinding hash_binding;
+	double correction;
+
+	PacAggregateHashInfo(LogicalAggregate *aggregate, unique_ptr<Expression> hash_expr, ColumnBinding hash_binding,
+	                     double correction)
+	    : aggregate(aggregate), hash_expr(std::move(hash_expr)), hash_binding(hash_binding), correction(correction) {
+	}
+};
 
 // Helper to ensure PK columns are present in a LogicalGet's column_ids and projection_ids.
 void AddPKColumns(LogicalGet &get, const vector<string> &pks);
@@ -23,11 +46,23 @@ void AddPKColumns(LogicalGet &get, const vector<string> &pks);
 void PopulateGetsFromFKPath(const PrivacyCompatibilityResult &check, vector<string> &gets_present,
                             vector<string> &gets_missing, string &start_table_out, vector<string> &target_pus_out);
 
+// Reuse the PAC FK-join materialization path so downstream code can find and propagate PU hashes.
+PacPUHashingSetup PreparePlanForPUHashing(const PrivacyCompatibilityResult &check, OptimizerExtensionInput &input,
+                                          unique_ptr<LogicalOperator> &plan, const vector<string> &privacy_units);
+
+// Shared PU hash propagation. Returns one propagated hash expression per aggregate selected by PAC's
+// target-aggregate discovery, without rebinding the aggregate expressions.
+vector<PacAggregateHashInfo> BuildPUHashExpressionsForAggregates(OptimizerExtensionInput &input,
+                                                                 unique_ptr<LogicalOperator> &plan,
+                                                                 const vector<string> &pu_table_names,
+                                                                 const PrivacyCompatibilityResult &check,
+                                                                 const CTETableMap &cte_map);
+
 // Unified aggregate transformation: builds hash expressions from PU/FK tables and
 // transforms aggregates to use PAC functions. Works for both direct-PU and FK-joined plans.
 void ModifyPlanWithPU(OptimizerExtensionInput &input, unique_ptr<LogicalOperator> &plan,
                       const vector<string> &pu_table_names, const PrivacyCompatibilityResult &check,
-                      const CTETableMap &cte_map);
+                      const CTETableMap &cte_map, PacAggregateInfoMap &pac_agg_info);
 
 // Bitslice-style PAC compiler entrypoint
 void CompilePacBitsliceQuery(const PrivacyCompatibilityResult &check, OptimizerExtensionInput &input,

--- a/test/sql/dp_sample_median.test
+++ b/test/sql/dp_sample_median.test
@@ -161,13 +161,165 @@ query II
 SELECT segment, COUNT(*) FROM events GROUP BY segment ORDER BY segment;
 ----
 
+query II
+SELECT segment, AVG(v) FROM events GROUP BY segment ORDER BY segment;
+----
+
 statement ok
 SET privacy_min_group_count = NULL;
+
+query III
+SELECT COUNT(*) BETWEEN 900 AND 1100, SUM(v) BETWEEN 900.0 AND 1100.0, AVG(v) BETWEEN 0.9 AND 1.1
+FROM events;
+----
+true	true	true
+
+query II
+SELECT segment, AVG(v) BETWEEN 0.9 AND 1.1
+FROM events
+GROUP BY segment
+HAVING AVG(v) > 0.5
+ORDER BY segment;
+----
+even	true
+odd	true
+
+query I
+SELECT AVG(v) FILTER (WHERE uid <= 500) BETWEEN 0.9 AND 1.1 FROM events;
+----
+true
+
+statement ok
+SET privacy_noise = true;
+
+query II
+SELECT AVG(v) IS NOT NULL, isfinite(AVG(v)) FROM events;
+----
+true	true
+
+statement ok
+SET privacy_noise = false;
+
+statement error
+SELECT COUNT(DISTINCT uid) FROM events;
+----
+DISTINCT
+
+statement error
+SELECT MIN(v) FROM events;
+----
+only COUNT, SUM, and AVG
+
+statement ok
+RESET dp_sum_bound;
 
 statement error
 SELECT AVG(v) FROM events;
 ----
-AVG is not supported
+dp_sum_bound
+
+statement ok
+SET dp_sum_bound = 1.0;
+
+statement ok
+SET pac_clip_support = 0;
+
+statement error
+SELECT AVG(v) FROM events;
+----
+pac_clip_support
+
+statement ok
+SET pac_clip_support = 1;
+
+statement ok
+CREATE TABLE clicks AS
+SELECT i AS uid, i % 3 AS clicks
+FROM range(1, 1001) t(i);
+
+statement ok
+ALTER TABLE clicks ADD PRIVACY_LINK (uid) REFERENCES users(uid);
+
+statement error
+SELECT COUNT(*)
+FROM users
+JOIN events ON users.uid = events.uid
+JOIN clicks ON users.uid = clicks.uid;
+----
+star/diamond
+
+statement error
+SELECT COUNT(*)
+FROM events e1
+JOIN events e2 ON e1.uid = e2.uid;
+----
+self-joins
+
+# Multi-hop chain: users2 <- orders2 <- lines2. Sample-median must reuse PAC's
+# FK join insertion and PU hash propagation rather than hashing the leaf key.
+statement ok
+CREATE TABLE users2 AS SELECT i AS uid FROM range(1, 1001) t(i);
+
+statement ok
+CREATE TABLE orders2 AS
+SELECT i AS oid, ((i - 1) % 1000) + 1 AS uid
+FROM range(1, 5001) t(i);
+
+statement ok
+CREATE TABLE lines2 AS
+SELECT i AS lid,
+       ((i - 1) % 5000) + 1 AS oid,
+       CASE WHEN i % 2 = 0 THEN 'even' ELSE 'odd' END AS segment,
+       2.0::DOUBLE AS price
+FROM range(1, 15001) t(i);
+
+statement ok
+ALTER TABLE users2 ADD PRIVACY_KEY (uid);
+
+statement ok
+ALTER TABLE users2 SET PU;
+
+statement ok
+ALTER TABLE orders2 ADD PRIVACY_KEY (oid);
+
+statement ok
+ALTER TABLE orders2 ADD PRIVACY_LINK (uid) REFERENCES users2(uid);
+
+statement ok
+ALTER TABLE lines2 ADD PRIVACY_LINK (oid) REFERENCES orders2(oid);
+
+statement ok
+SET dp_sum_bound = 2.0;
+
+statement ok
+SET pac_clip_support = 1;
+
+query III
+SELECT COUNT(*) BETWEEN 13000 AND 17000,
+       SUM(price) BETWEEN 26000.0 AND 34000.0,
+       AVG(price) BETWEEN 1.8 AND 2.2
+FROM users2
+JOIN orders2 ON users2.uid = orders2.uid
+JOIN lines2 ON orders2.oid = lines2.oid;
+----
+true	true	true
+
+query III
+SELECT COUNT(*) BETWEEN 13000 AND 17000,
+       SUM(price) BETWEEN 26000.0 AND 34000.0,
+       AVG(price) BETWEEN 1.8 AND 2.2
+FROM lines2;
+----
+true	true	true
+
+query II
+SELECT segment, AVG(price) BETWEEN 1.8 AND 2.2
+FROM lines2
+GROUP BY segment
+ORDER BY segment;
+----
+even	true
+odd	true
 
 statement ok
 SET dp_strategy = 'elastic';


### PR DESCRIPTION
## Summary

This PR adds the DP sample-median smooth-sensitivity path on top of the existing PAC rewrite machinery. The main goal is to stop maintaining a separate DP-only PU hash path and instead reuse PAC's FK-join insertion and privacy-unit hash propagation for sample-median DP queries.

It also extends sample-median DP from COUNT/SUM to AVG by reusing the existing DP AVG rewrite pattern: AVG is decomposed into SUM and COUNT, each component is noised separately, and the final projection computes the ratio. Hidden AVG components stay DOUBLE until the ratio projection so noisy denominators and sums are not truncated before division.

## Code Flow

For `dp_strategy = 'sample_median'`, compilation now follows this path:

1. Validate DP settings (`dp_epsilon`, `dp_delta`) and the supported aggregate/query shape.
2. Validate that the query has the same linear FK/self-join shape expected by DP, but do not build elastic-sensitivity FK-column metadata for sample-median.
3. Rewrite AVG into SUM plus COUNT components.
4. For SUM/AVG, require `dp_sum_bound` and `pac_clip_support`, then clip SUM inputs before aggregation.
5. Call the shared PAC setup to insert any missing FK joins and propagate the PU hash to the target aggregate.
6. Rewrite the aggregate to sample-median counters using that propagated PU hash.
7. Apply `privacy_min_group_count` before noising when configured.
8. Project `dp_smooth_median_noise` over each release, splitting both epsilon and delta across visible releases and AVG components.
9. For AVG, add a final ratio projection above the noise projection.

## Refactor

The second commit removes duplicated projection insertion/remapping code in the DP compiler. Elastic Laplace noise, sample-median smooth noise, and AVG ratio rewrites now share one helper for inserting a projection and remapping upstream column bindings. The helper keeps the aggregate-column source offset explicit, which matters for grouped AVG ratio projections where group columns and aggregate columns come from the same intermediate projection.

The refactor also separates aggregate validation from FK-chain extraction. Elastic still extracts the full FK chain needed for sensitivity computation; sample-median only validates the query shape and then delegates PU hash discovery to the PAC path.

## Local Validation

Built the release extension and ran the focused SQL suites for `dp_sample_median`, `dp_elastic`, `pac_plan`, and `pac_clip_sum`. I also ran a real DuckDB CLI grouped noisy sample-median AVG query and verified both groups returned finite DOUBLE results.
